### PR TITLE
add err check for json.Unmarshal call

### DIFF
--- a/api/keyconjurer/user_data.go
+++ b/api/keyconjurer/user_data.go
@@ -78,6 +78,9 @@ func (u *UserData) UnmarshalJSON(data []byte) error {
 
 	var creds string
 	err = json.Unmarshal(*objmap["creds"], &creds)
+	if err != nil {
+		return nil
+	}
 
 	authAccounts := make([]authenticators.Account, len(apps))
 	for index, app := range apps {


### PR DESCRIPTION
Noticed one of the `json.Unmarshal` calls in the `UnmarshalJSON` function didn't have a check for the returned `err` value so small PR to add that. 