### PR TITLE
Detecting PowerShell Core (6+) shells

### DIFF
--- a/cli/keyconjurer/awskey_cli.go
+++ b/cli/keyconjurer/awskey_cli.go
@@ -93,7 +93,7 @@ func getShellType() string {
 	parentProc, _ := ps.FindProcess(pid)
 	normalizedName := strings.ToLower(parentProc.Executable())
 
-	if strings.Contains(normalizedName, "powershell") {
+	if (strings.Contains(normalizedName, "powershell") || strings.Contains(normalizedName, "pwsh")) {
 		return "powershell"
 	}
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Newer versions of PowerShell (PowerShell Core 6, and PowerShell 7) use the `pwsh.exe` executable name, which wasn't recognized by `getShellType()`. This pull request simply checks for that other executable name.