### PR TITLE
Improve error handling and quiet the CLI

### DIFF
--- a/api/keyconjurer/authenticator.go
+++ b/api/keyconjurer/authenticator.go
@@ -11,15 +11,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func newAuthenticator(logger *logrus.Entry, keyConjurerSettings *settings.Settings) authenticators.Authenticator {
-	var authenticator authenticators.Authenticator
+var errNoAuthenticatorSelected = errors.New("no authenticator selected")
 
+func newAuthenticator(logger *logrus.Entry, keyConjurerSettings *settings.Settings) (authenticators.Authenticator, error) {
+	var authenticator authenticators.Authenticator
 	switch consts.AuthenticatorSelect {
 	case "onelogin":
 		logger.Info("using onelogin authenticator")
 		authenticator = oneloginduo.New(logger, keyConjurerSettings)
 	default:
-		panic(errors.New("No Authenticator Selected"))
+		return nil, errNoAuthenticatorSelected
 	}
 
 	switch consts.MFASelect {
@@ -28,8 +29,8 @@ func newAuthenticator(logger *logrus.Entry, keyConjurerSettings *settings.Settin
 		duo := oneloginduo.NewDuoMFA(logger)
 		authenticator.SetMFA(duo)
 	default:
-		panic(errors.New("No Authenticator Selected"))
+		return nil, errNoAuthenticatorSelected
 	}
 
-	return authenticator
+	return authenticator, nil
 }

--- a/api/keyconjurer/serverless_functions.go
+++ b/api/keyconjurer/serverless_functions.go
@@ -28,9 +28,15 @@ type GetUserDataEvent struct {
 // GetUserDataEventHandler authenticates the user against OneLogin and retrieves a list of AWS application the user has available
 func GetUserDataEventHandler(event GetUserDataEvent) (*Response, error) {
 	logger := log.NewLogger(event.Client, event.ClientVersion, logrus.DebugLevel)
-	keyConjurerSettings := settings.NewSettings(logger)
+	keyConjurerSettings, err := settings.NewSettings(logger)
+	if err != nil {
+		return CreateResponseError(err.Error()), err
+	}
 
-	auth := newAuthenticator(logger, keyConjurerSettings)
+	auth, err := newAuthenticator(logger, keyConjurerSettings)
+	if err != nil {
+		return CreateResponseError(err.Error()), err
+	}
 
 	// make new keyconjurer instance
 	client, err := NewKeyConjurer(auth, logger, keyConjurerSettings)
@@ -89,9 +95,15 @@ type GetTemporaryCredentialEvent struct {
 
 func GetTemporaryCredentialEventHandler(event GetTemporaryCredentialEvent) (*Response, error) {
 	logger := log.NewLogger(event.Client, event.ClientVersion, logrus.DebugLevel)
-	keyConjurerSettings := settings.NewSettings(logger)
+	keyConjurerSettings, err := settings.NewSettings(logger)
+	if err != nil {
+		return CreateResponseError(err.Error()), err
+	}
 
-	auth := newAuthenticator(logger, keyConjurerSettings)
+	auth, err := newAuthenticator(logger, keyConjurerSettings)
+	if err != nil {
+		return CreateResponseError(err.Error()), err
+	}
 
 	// make new keyconjurer instance
 	client, err := NewKeyConjurer(auth, logger, keyConjurerSettings)

--- a/api/keyconjurer/serverless_functions.go
+++ b/api/keyconjurer/serverless_functions.go
@@ -25,8 +25,7 @@ type GetUserDataEvent struct {
 	ShouldEncryptCreds bool   `json:"shouldEncryptCreds"`
 }
 
-// GetUserData authenticates the user against OneLogin and retrieves a list of
-//  AWS application the user has available
+// GetUserDataEventHandler authenticates the user against OneLogin and retrieves a list of AWS application the user has available
 func GetUserDataEventHandler(event GetUserDataEvent) (*Response, error) {
 	logger := log.NewLogger(event.Client, event.ClientVersion, logrus.DebugLevel)
 	keyConjurerSettings := settings.NewSettings(logger)
@@ -34,7 +33,10 @@ func GetUserDataEventHandler(event GetUserDataEvent) (*Response, error) {
 	auth := newAuthenticator(logger, keyConjurerSettings)
 
 	// make new keyconjurer instance
-	client := NewKeyConjurer(event.Client, event.ClientVersion, auth, logger, keyConjurerSettings)
+	client, err := NewKeyConjurer(auth, logger, keyConjurerSettings)
+	if err != nil {
+		return CreateResponseError(err.Error()), err
+	}
 
 	// get username:password and decrypt if necessary
 
@@ -75,7 +77,7 @@ func GetUserDataEventHandler(event GetUserDataEvent) (*Response, error) {
 ///////////////////////////////////////////////////////////
 
 // Event holds incoming data from the user
-//  AppID is the OneLogin AppID
+// AppID is the OneLogin AppID
 type GetTemporaryCredentialEvent struct {
 	Username       string `json:"username"`
 	Password       string `json:"password"`
@@ -92,7 +94,10 @@ func GetTemporaryCredentialEventHandler(event GetTemporaryCredentialEvent) (*Res
 	auth := newAuthenticator(logger, keyConjurerSettings)
 
 	// make new keyconjurer instance
-	client := NewKeyConjurer(event.Client, event.ClientVersion, auth, logger, keyConjurerSettings)
+	client, err := NewKeyConjurer(auth, logger, keyConjurerSettings)
+	if err != nil {
+		return CreateResponseError(err.Error()), err
+	}
 
 	user, err := client.providerClient.GetUserCredentials(event.Username, event.Password)
 	if err != nil {

--- a/api/settings/settings.go
+++ b/api/settings/settings.go
@@ -20,11 +20,11 @@ type Settings struct {
 	OneLoginSubdomain      string `json:"oneLoginSubdomain"`
 }
 
-type SettingsRetrieverFunc = func(logger *logrus.Entry) *Settings
+type SettingsRetrieverFunc = func(logger *logrus.Entry) (*Settings, error)
 
 var SettingsRetrievers = map[string]SettingsRetrieverFunc{}
 
-func NewSettings(logger *logrus.Entry) *Settings {
+func NewSettings(logger *logrus.Entry) (*Settings, error) {
 	logger.Infof("Settings Retriever in Use: %s", consts.SettingsRetrieverSelect)
 	return SettingsRetrievers[consts.SettingsRetrieverSelect](logger)
 }
@@ -33,5 +33,6 @@ func registerRetriever(name string, retrieverFunc SettingsRetrieverFunc) {
 	if _, ok := SettingsRetrievers[name]; ok {
 		log.Fatalf("Already had registered retriever: %s", name)
 	}
+
 	SettingsRetrievers[name] = retrieverFunc
 }

--- a/cli/cmd/accounts.go
+++ b/cli/cmd/accounts.go
@@ -19,8 +19,12 @@ var accountsCmd = &cobra.Command{
 	Short:   "Prints the list of accounts you have access to.",
 	Long:    "Prints the list of accounts you have access to.",
 	Example: "keyconjurer accounts",
-	Run: func(cmd *cobra.Command, args []string) {
-		userData := keyconjurer.Login(keyConjurerRcPath, false)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		userData, err := keyconjurer.Login(keyConjurerRcPath, false)
+		if err != nil {
+			return err
+		}
+
 		//need update path
-		userData.ListAccounts()
+		return userData.ListAccounts()
 	}}

--- a/cli/cmd/alias.go
+++ b/cli/cmd/alias.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/riotgames/key-conjurer/cli/keyconjurer"
 
 	"github.com/spf13/cobra"
@@ -14,15 +12,17 @@ var aliasCmd = &cobra.Command{
 	Long:    "Alias an account to a nickname so you can refer to the account by the nickname.",
 	Args:    cobra.ExactArgs(2),
 	Example: "keyconjurer alias FooAccount Bar",
-	Run: func(cmd *cobra.Command, args []string) {
-		userData := keyconjurer.Login(keyConjurerRcPath, false)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		userData, err := keyconjurer.Login(keyConjurerRcPath, false)
+		if err != nil {
+			return err
+		}
+
 		account := args[0]
 		alias := args[1]
 		if err := userData.NewAlias(account, alias); err != nil {
-			log.Println(err.Error())
+			return err
 		}
 
-		if err := userData.Save(); err != nil {
-			log.Println(err)
-		}
+		return userData.Save()
 	}}

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/riotgames/key-conjurer/cli/keyconjurer"
 
 	"github.com/spf13/cobra"
@@ -14,10 +12,12 @@ var loginCmd = &cobra.Command{
 	Long: `Login using your AD creds.  This stores encrypted credentials
 on the local system`,
 	Example: "keyconjurer login",
-	Run: func(cmd *cobra.Command, args []string) {
-		userData := keyconjurer.Login(keyConjurerRcPath, true)
-		if err := userData.Save(); err != nil {
-			log.Println(err)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		userData, err := keyconjurer.Login(keyConjurerRcPath, false)
+		if err != nil {
+			return err
 		}
+
+		return userData.Save()
 	},
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,22 +2,19 @@ package cmd
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/riotgames/key-conjurer/cli/keyconjurer"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var keyConjurerRcPath string
-var logLevel string
-var devFlag bool
+var (
+	keyConjurerRcPath string
+	devFlag           bool
+)
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&keyConjurerRcPath, "keyconjurer-rc-path", "~/.keyconjurerrc", "path to .keyconjurerrc file")
-	rootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", logrus.ErrorLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().BoolVarP(&devFlag, "dev", "d", false, "flag to use dev server")
 	rootCmd.SetVersionTemplate(`{{printf "%s" .Version}}`)
 	rootCmd.AddCommand(loginCmd)
@@ -43,28 +40,12 @@ keyconjurer accounts
 keyconjurer get <accountName>
 `,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		setKeyConjurerLogger()
 		keyconjurer.Dev = devFlag
 	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		log.Println(err)
-		os.Exit(1)
-	}
-}
-
-func setKeyConjurerLogger() {
-	logger := logrus.New()
-	logger.SetOutput(os.Stderr)
-	level, err := logrus.ParseLevel(logLevel)
-	if err != nil {
-		log.Fatal(err)
-	}
-	logger.SetLevel(level)
-
-	keyconjurer.Logger = logger
+func Execute() error {
+	return rootCmd.Execute()
 }

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -1,8 +1,7 @@
 package cmd
 
 import (
-	"log"
-	"os"
+	"fmt"
 	"strconv"
 
 	"github.com/riotgames/key-conjurer/cli/keyconjurer"
@@ -25,15 +24,19 @@ var setTTLCmd = &cobra.Command{
 	Short: "Sets ttl value in number of hours.",
 	Long:  "Sets ttl value in number of hours.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		userData := keyconjurer.Login(keyConjurerRcPath, false)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		userData, err := keyconjurer.Login(keyConjurerRcPath, false)
+		if err != nil {
+			return err
+		}
+
 		ttl, err := strconv.ParseUint(args[0], 10, 32)
 		if err != nil {
-			log.Printf("Unable to parse value %v\n", args[0])
-			os.Exit(1)
+			return fmt.Errorf("unable to parse value %s", args[0])
 		}
+
 		userData.SetTTL(uint(ttl))
-		userData.Save()
+		return userData.Save()
 	}}
 
 var setTimeRemainingCmd = &cobra.Command{
@@ -41,13 +44,17 @@ var setTimeRemainingCmd = &cobra.Command{
 	Short: "Sets time remaining value in number of minutes.",
 	Long:  "Sets time remaining value in number of minutes. Using minutes is an artifact from when keys could only live for 1 hour.",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		userData := keyconjurer.Login(keyConjurerRcPath, false)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		userData, err := keyconjurer.Login(keyConjurerRcPath, false)
+		if err != nil {
+			return err
+		}
+
 		timeRemaining, err := strconv.ParseUint(args[0], 10, 32)
 		if err != nil {
-			log.Printf("Unable to parse value %v\n", args[0])
-			os.Exit(1)
+			return fmt.Errorf("unable to parse value %s", args[0])
 		}
+
 		userData.SetTimeRemaining(uint(timeRemaining))
-		userData.Save()
+		return userData.Save()
 	}}

--- a/cli/cmd/unalias.go
+++ b/cli/cmd/unalias.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"log"
-	"os"
-
 	"github.com/riotgames/key-conjurer/cli/keyconjurer"
 
 	"github.com/spf13/cobra"
@@ -16,16 +12,15 @@ var unaliasCmd = &cobra.Command{
 	Long:    "Removes alias from account. The positional arg can refer to the account by name or alias.",
 	Args:    cobra.ExactArgs(1),
 	Example: "keyconjurer alias FooAccount Bar",
-	Run: func(cmd *cobra.Command, args []string) {
-		userData := keyconjurer.Login(keyConjurerRcPath, false)
-		account := args[0]
-		if err := userData.RemoveAlias(account); err != nil {
-			fmt.Println(err.Error())
+	RunE: func(cmd *cobra.Command, args []string) error {
+		userData, err := keyconjurer.Login(keyConjurerRcPath, false)
+		if err != nil {
+			return err
 		}
 
-		if err := userData.Save(); err != nil {
-			log.Println(err)
-			log.Printf("Unable to save user data to %v\n", keyConjurerRcPath)
-			os.Exit(1)
+		if err := userData.RemoveAlias(args[0]); err != nil {
+			return err
 		}
+
+		return userData.Save()
 	}}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/sirupsen/logrus v1.6.0
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -56,8 +56,6 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -93,8 +91,6 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
-github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a h1:pa8hGb/2YqsZKovtsgrwcDH1RZhVbTKCjLp47XpqCDs=
@@ -148,7 +144,6 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 h1:W0lCpv29Hv0UaM1LXb9QlBHLNP8UFfcKjblhVCWftOM=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/cli/keyconjurer/account.go
+++ b/cli/keyconjurer/account.go
@@ -27,17 +27,14 @@ func (a *Account) isNameMatch(name string) bool {
 	// Purposefully not checking the lowercase version of app.Alias
 	//  as the user should match the alias provided
 	if strings.ToLower(a.Name) == strings.ToLower(name) {
-		Logger.Debugln("matched on lower(Name)")
 		return true
 	}
 
 	if strings.ToLower(a.normalizeName()) == strings.ToLower(name) {
-		Logger.Debugln("matched on normalized name")
 		return true
 	}
 
 	if a.Alias == name {
-		Logger.Debugln("matched on alias")
 		return true
 	}
 
@@ -46,7 +43,6 @@ func (a *Account) isNameMatch(name string) bool {
 
 func (a *Account) setAlias(alias string) {
 	if alias == "" {
-		Logger.Warn("Alias is emtpy string and will be  set to default alias")
 		a.defaultAlias()
 	} else {
 		a.Alias = alias

--- a/cli/keyconjurer/account_test.go
+++ b/cli/keyconjurer/account_test.go
@@ -1,25 +1,10 @@
 package keyconjurer
 
 import (
-	"log"
-	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
-
-func init() {
-	logger := logrus.New()
-	logger.SetOutput(os.Stderr)
-	level, err := logrus.ParseLevel("debug")
-	if err != nil {
-		log.Fatal(err)
-	}
-	logger.SetLevel(level)
-
-	Logger = logger
-}
 
 func TestAccountFuncs(t *testing.T) {
 	test := &Account{

--- a/cli/keyconjurer/aws_cli_file_manager.go
+++ b/cli/keyconjurer/aws_cli_file_manager.go
@@ -2,6 +2,8 @@ package keyconjurer
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/go-ini/ini"
@@ -11,11 +13,6 @@ import (
 type awsCli struct {
 	creds  *awsCliCredentialsFile
 	config *awsCliConfigFile
-}
-
-type awsCliCredentialsFile struct {
-	*ini.File
-	Path string
 }
 
 type awsCliConfigFile struct {
@@ -35,11 +32,6 @@ type AWSCliEntry struct {
 }
 
 func NewAWSCliEntry(c *Credentials, a *Account) *AWSCliEntry {
-
-	if a.Alias == "" {
-		Logger.Warn("Alias is an empty string and profile will be set to default alias")
-	}
-
 	a.defaultAlias()
 
 	return &AWSCliEntry{
@@ -50,60 +42,64 @@ func NewAWSCliEntry(c *Credentials, a *Account) *AWSCliEntry {
 	}
 }
 
-func getAwsCliCredentialsFile(credsPath string) *awsCliCredentialsFile {
-	fullCredsPath, err := homedir.Expand(credsPath)
-
-	if err != nil {
-		Logger.Errorln("unable to expand path to aws-cli credentials file")
-		Logger.Errorln(err)
-		return &awsCliCredentialsFile{}
-	}
-
-	Logger.Infof("reading aws-cli creds from %s\n", fullCredsPath)
-
-	creds := &awsCliCredentialsFile{Path: fullCredsPath}
-
-	creds.File, err = ini.Load(fullCredsPath)
-	if err != nil {
-		Logger.Errorln("could not read aws-cli credentials file")
-		Logger.Errorln(err)
-		return creds
-	}
-
-	return creds
+type awsCliCredentialsFile struct {
+	*ini.File
+	Path string
 }
 
-func getAwsCliConfigFile(configPath string) *awsCliConfigFile {
-	fullConfigPath, err := homedir.Expand(configPath)
-	if err != nil {
-		Logger.Errorln("unable to expand path to aws-cli config file")
-		Logger.Errorln(err)
-		return &awsCliConfigFile{}
-	}
-
-	Logger.Infof("reading aws-cli config from %v\n", fullConfigPath)
-
-	config := &awsCliConfigFile{Path: fullConfigPath}
-
-	config.File, err = ini.Load(fullConfigPath)
-	if err != nil {
-		Logger.Errorln("could not read aws-cli config file")
-		Logger.Errorln(err)
-		return config
-	}
-
-	return config
+func touchFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 }
 
-func getAwsCliByPath(path string) *awsCli {
+func getAwsCliCredentialsFile(credsPath string) (*awsCliCredentialsFile, error) {
+	path, err := homedir.Expand(credsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := touchFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var creds awsCliCredentialsFile
+	creds.File, err = ini.Load(b)
+	return &creds, err
+}
+
+func getAwsCliConfigFile(configPath string) (*awsCliConfigFile, error) {
+	path, err := homedir.Expand(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := touchFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg awsCliConfigFile
+	cfg.File, err = ini.Load(b)
+	return &cfg, err
+}
+
+func getAwsCliByPath(path string) (*awsCli, error) {
 	fullPath, err := homedir.Expand(path)
 	if err != nil {
-		Logger.Errorln("unable to expand path to aws-cli dir")
-		Logger.Errorln(err)
-		return &awsCli{}
+		return nil, err
 	}
-
-	Logger.Infof("using aws-cli dir %s\n", fullPath)
 
 	var configPath string
 	var credsPath string
@@ -115,64 +111,67 @@ func getAwsCliByPath(path string) *awsCli {
 		credsPath = fmt.Sprintf("%s/%s", fullPath, "credentials")
 	}
 
-	touchFileIfNotExist(configPath)
-	touchFileIfNotExist(credsPath)
-
-	return &awsCli{
-		creds:  getAwsCliCredentialsFile(credsPath),
-		config: getAwsCliConfigFile(configPath),
+	creds, err := getAwsCliCredentialsFile(configPath)
+	if err != nil {
+		return nil, err
 	}
+
+	cfg, err := getAwsCliConfigFile(credsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &awsCli{creds: creds, config: cfg}, nil
 }
 
 // stub for use if we end up managing config file at some point
 // func StubThatDoesNothing(){}
 // func saveConfigEntry(alias, region, output string) {}
 
-func (a *awsCli) saveCredentialEntry(entry *AWSCliEntry) {
+func (a *awsCli) saveCredentialEntry(entry *AWSCliEntry) error {
 	var section *ini.Section
 
 	section, err := a.creds.GetSection(entry.profileName)
 	if err != nil {
 		// create new section
 		section, err = a.creds.NewSection(entry.profileName)
-		if err != nil {
-			Logger.Errorln("error making new aws cli section: ", err)
-		}
+		return err
 	}
 
 	if section.HasKey("aws_access_key_id") {
 		section.Key("aws_access_key_id").SetValue(entry.keyId)
 	} else {
 		_, err := section.NewKey("aws_access_key_id", entry.keyId)
-		if err != nil {
-			Logger.Errorln("error making new aws cli key: ", err)
-		}
+		return err
 	}
 
 	if section.HasKey("aws_secret_access_key") {
 		section.Key("aws_secret_access_key").SetValue(entry.key)
 	} else {
 		_, err := section.NewKey("aws_secret_access_key", entry.key)
-		if err != nil {
-			Logger.Errorln("error making new aws cli key: ", err)
-		}
+		return err
 	}
 
 	if section.HasKey("aws_session_token") {
 		section.Key("aws_session_token").SetValue(entry.token)
 	} else {
 		_, err := section.NewKey("aws_session_token", entry.token)
-		if err != nil {
-			Logger.Errorln("error making new aws cli key: ", err)
-		}
+		return err
 	}
+
+	return nil
 }
 
 func SaveAWSCredentialInCLI(awscliPath string, entries ...*AWSCliEntry) error {
-	cli := getAwsCliByPath(awscliPath)
+	cli, err := getAwsCliByPath(awscliPath)
+	if err != nil {
+		return err
+	}
 
 	for _, entry := range entries {
-		cli.saveCredentialEntry(entry)
+		if err := cli.saveCredentialEntry(entry); err != nil {
+			return err
+		}
 	}
 
 	cli.creds.SaveTo(cli.creds.Path)

--- a/cli/keyconjurer/aws_cli_file_manager_test.go
+++ b/cli/keyconjurer/aws_cli_file_manager_test.go
@@ -1,49 +1,27 @@
 package keyconjurer
 
 import (
-	"log"
-	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	logger := logrus.New()
-	logger.SetOutput(os.Stderr)
-	level, err := logrus.ParseLevel("debug")
-	if err != nil {
-		log.Fatal(err)
-	}
-	logger.SetLevel(level)
-
-	Logger = logger
-}
-
 func TestAwsCliCredsFile(t *testing.T) {
-	credsPath := "~/.aws/credentials"
-	t.Log("reading in ", credsPath)
-	credsFile := getAwsCliCredentialsFile(credsPath)
+	credsFile, _ := getAwsCliCredentialsFile("~/.aws/credentials")
 	for _, section := range credsFile.Sections() {
 		t.Log(section.Name(), section.KeyStrings())
 	}
 }
 
 func TestAwsCliConfigFile(t *testing.T) {
-	configPath := "~/.aws/config"
-	t.Log("reading in ", configPath)
-	configFile := getAwsCliConfigFile(configPath)
+	configFile, _ := getAwsCliConfigFile("~/.aws/config")
 	for _, section := range configFile.Sections() {
 		t.Log(section.Name(), section.KeyStrings())
 	}
 }
 
 func TestAwsCliFileNoSlash(t *testing.T) {
-	path := "~/.aws"
-
-	awscli := getAwsCliByPath(path)
-
+	awscli, _ := getAwsCliByPath("~/.aws")
 	for _, section := range awscli.creds.Sections() {
 		t.Log(section.Name(), section.Keys())
 	}
@@ -54,10 +32,7 @@ func TestAwsCliFileNoSlash(t *testing.T) {
 }
 
 func TestAwsCliFileWithSlash(t *testing.T) {
-	path := "~/.aws/"
-
-	awscli := getAwsCliByPath(path)
-
+	awscli, _ := getAwsCliByPath("~/.aws/")
 	for _, section := range awscli.creds.Sections() {
 		t.Log(section.Name(), section.Keys())
 	}
@@ -68,10 +43,7 @@ func TestAwsCliFileWithSlash(t *testing.T) {
 }
 
 func TestAddAWSCliEntry(t *testing.T) {
-	path := "~/.aws/"
-
-	awscli := getAwsCliByPath(path)
-
+	awscli, _ := getAwsCliByPath("~/.aws/")
 	entry := &AWSCliEntry{
 		profileName: "test-profile",
 		keyId:       "notanid",
@@ -97,9 +69,7 @@ func TestAddAWSCliEntry(t *testing.T) {
 	awscli.creds.SaveTo(awscli.creds.Path)
 
 	// retest by reloading into file
-	awscli = &awsCli{}
-	awscli = getAwsCliByPath(path)
-
+	awscli, _ = getAwsCliByPath("~/.aws/")
 	assert.Equal(t, true, awscli.creds.Section("test-profile") != nil, "section should have been added above")
 
 	testSection = awscli.creds.Section("test-profile")

--- a/cli/keyconjurer/awskey_cli.go
+++ b/cli/keyconjurer/awskey_cli.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,58 +15,44 @@ import (
 
 	homedir "github.com/mitchellh/go-homedir"
 	ps "github.com/mitchellh/go-ps"
-	"github.com/sirupsen/logrus"
 )
-
-var Logger *logrus.Logger
 
 // Login prompts the user for the AD credentials and then passes back the list
 //  of AWS applications and encrypted creds via the inputed userData
-func Login(keyConjurerRcPath string, prompt bool) *UserData {
-	shouldPrompt := prompt
-
-	expandedKeyConjurerRcPath, err := homedir.Expand(keyConjurerRcPath)
+func Login(keyConjurerRcPath string, prompt bool) (*UserData, error) {
+	reader, err := openKeyConjurerRc(keyConjurerRcPath)
 	if err != nil {
-		Logger.Errorln(err)
-		Logger.Fatalf("Can't expand location %v", keyConjurerRcPath)
-
-		// do we want to exit if we cant expand the path???
+		return nil, err
 	}
 
-	touchFileIfNotExist(expandedKeyConjurerRcPath)
-	userData := &UserData{
-		filePath: expandedKeyConjurerRcPath,
-	}
+	defer reader.Close()
 
-	if err := userData.LoadFromFile(); err != nil {
-		Logger.Warnf("unable to load keyconjurerrc at location %s\n", expandedKeyConjurerRcPath)
-		Logger.Warnln(err)
+	var userData UserData
+	if err := userData.Load(reader); err != nil {
 		userData.SetDefaults()
-		shouldPrompt = true
+		prompt = true
 	}
 
-	if shouldPrompt {
-		err = userData.promptForADCreds()
-
-		if err != nil {
-			Logger.Error("error using provided AD credentials")
-			Logger.Fatal(err)
-
-		}
-
-		err = userData.Save()
-
-		if err != nil {
-			Logger.Error("error saving user data")
-			Logger.Fatal(err)
-		}
-		fmt.Println("Successfully logged in")
+	if !prompt {
+		return &userData, nil
 	}
-	return userData
 
+	if err := userData.promptForADCreds(); err != nil {
+		return nil, fmt.Errorf("error using provided AD credentials: %w", err)
+	}
+
+	if err := userData.Save(); err != nil {
+		return nil, fmt.Errorf("error saving user data: %w", err)
+	}
+
+	// Don't like this, nope
+	fmt.Println("Successfully logged in")
+	return &userData, nil
 }
 
-// GetUsernameAndPassword prompts the user for their username and password via stdin
+var errUnableToReadUsername = errors.New("unable to read username")
+
+// getUsernameAndPassword prompts the user for their username and password via stdin
 func getUsernameAndPassword() (string, string, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	fmt.Printf("username: ")
@@ -73,15 +60,15 @@ func getUsernameAndPassword() (string, string, error) {
 	if scanner.Scan() {
 		username = scanner.Text()
 	} else {
-		return "", "", errors.New("Unable to get username")
+		return "", "", errUnableToReadUsername
 	}
 
 	fmt.Printf("password: ")
 	bytes, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
-		Logger.Warn("Unable to get password")
-		return "", "", errors.New("Unable to get password")
+		return "", "", fmt.Errorf("unable to get password: %w", err)
 	}
+
 	password := string(bytes)
 	// Need to add our own newline
 	fmt.Println()
@@ -102,23 +89,17 @@ func getShellType() string {
 	return normalizedName
 }
 
-func touchFileIfNotExist(path string) {
-	if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
-		errmkdir := os.MkdirAll(filepath.Dir(path), os.ModeDir|os.FileMode(uint32(0755)))
-		if errmkdir != nil {
-			Logger.Fatal(errmkdir)
-		}
-	} else if err != nil {
-		Logger.Fatal(err)
+func openKeyConjurerRc(path string) (io.ReadCloser, error) {
+	// It is probably an error if keyconjurerrc can't be read from
+	expanded, err := homedir.Expand(path)
+	if err != nil {
+		return nil, fmt.Errorf("can't expand location %s", path)
 	}
 
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		f, errCreate := os.Create(path)
-		if errCreate != nil {
-			Logger.Fatal(err)
-		}
-		f.Close()
-	} else if err != nil {
-		Logger.Fatal(err)
+	dir := filepath.Dir(expanded)
+	if err := os.MkdirAll(dir, os.ModeDir|os.FileMode(0755)); err != nil {
+		return nil, err
 	}
+
+	return os.OpenFile(expanded, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 }

--- a/cli/keyconjurer/credentials.go
+++ b/cli/keyconjurer/credentials.go
@@ -1,8 +1,10 @@
 package keyconjurer
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -56,7 +58,16 @@ func GetCredentials(u *UserData, accountName string, ttl uint) (*Credentials, er
 // requests a set of temporary credentials for the requested AWS account and returns
 //  them via the inputed credentials
 func getCredentialsFromKeyConjurer(encryptedAD string, account *Account, ttl uint) (*Credentials, error) {
-	data, err := newKeyConjurerCredRequestJSON(Client, Version, "encrypted", encryptedAD, account.ID, ttl)
+	request := CredsRequest{
+		Client:         Client,
+		ClientVersion:  Version,
+		Username:       "encrypted",
+		Password:       encryptedAD,
+		AppID:          strconv.FormatUint(uint64(account.ID), 10),
+		TimeoutInHours: ttl,
+	}
+
+	data, err := json.Marshal(request)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/keyconjurer/credentials_test.go
+++ b/cli/keyconjurer/credentials_test.go
@@ -1,13 +1,11 @@
 package keyconjurer
 
 import (
-	"log"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,20 +24,9 @@ func init() {
 		"AWSKEY_EXPIRATION",
 		"AWSKEY_ACCOUNT",
 	}
-
-	logger := logrus.New()
-	logger.SetOutput(os.Stderr)
-	level, err := logrus.ParseLevel("debug")
-	if err != nil {
-		log.Fatal(err)
-	}
-	logger.SetLevel(level)
-
-	Logger = logger
 }
 
 func resetEnv(t *testing.T, env []string) {
-	//log.Println("current env: ", env)
 	currentEnv := map[string]string{}
 	for _, kvstring := range env {
 		kv := strings.Split(kvstring, "=")

--- a/cli/keyconjurer/http_client.go
+++ b/cli/keyconjurer/http_client.go
@@ -92,7 +92,7 @@ func doKeyConjurerAPICall(url string, data []byte, responseStruct interface{}) e
 	return errors.New(errorMessage)
 }
 
-type KeyConjurerUserRequest struct {
+type UserRequest struct {
 	Client             string `json:"client"`
 	ClientVersion      string `json:"clientVersion"`
 	Username           string `json:"username"`
@@ -100,34 +100,13 @@ type KeyConjurerUserRequest struct {
 	ShouldEncryptCreds bool   `json:"shouldEncryptCreds"`
 }
 
-func newKeyConjurerUserRequestJSON(client, version, username, password string) ([]byte, error) {
-	return json.Marshal(KeyConjurerUserRequest{
-		Client:             client,
-		ClientVersion:      version,
-		Username:           username,
-		Password:           password,
-		ShouldEncryptCreds: true},
-	)
-}
-
-type KeyConjurerCredsRequest struct {
+type CredsRequest struct {
 	Client         string `json:"client"`
 	ClientVersion  string `json:"clientVersion"`
 	Username       string `json:"username"`
 	Password       string `json:"password"`
 	AppID          string `json:"appId"`
 	TimeoutInHours uint   `json:"timeoutInHours"`
-}
-
-func newKeyConjurerCredRequestJSON(client, version, username, password string, id, ttl uint) ([]byte, error) {
-	return json.Marshal(KeyConjurerCredsRequest{
-		Client:         client,
-		ClientVersion:  version,
-		Username:       username,
-		Password:       password,
-		AppID:          fmt.Sprint(id),
-		TimeoutInHours: ttl,
-	})
 }
 
 // ResponseData is the standard response structure from the Key Conjurer API

--- a/cli/keyconjurer/http_client.go
+++ b/cli/keyconjurer/http_client.go
@@ -14,9 +14,8 @@ import (
 	rootcerts "github.com/hashicorp/go-rootcerts"
 )
 
-// Creates a httpclient singleton that loads the user's system's CA. Note that
-//  this singleton is probably not multi-thread safe.
-func getHTTPClientSingleton() (*http.Client, error) {
+// createHTTPClient creates a new HTTP client that loads the operating system's CAs.
+func createHTTPClient() (*http.Client, error) {
 	certs, err := rootcerts.LoadSystemCAs()
 	if err != nil {
 		return nil, fmt.Errorf("Could not load System root CA files. Reason: %v", err)
@@ -48,7 +47,7 @@ func createAPIURL(path string) string {
 }
 
 func doKeyConjurerAPICall(url string, data []byte, responseStruct interface{}) error {
-	httpClient, err := getHTTPClientSingleton()
+	httpClient, err := createHTTPClient()
 	if err != nil {
 		return err
 	}

--- a/cli/keyconjurer/http_client_test.go
+++ b/cli/keyconjurer/http_client_test.go
@@ -1,25 +1,10 @@
 package keyconjurer
 
 import (
-	"log"
-	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
-
-func init() {
-	logger := logrus.New()
-	logger.SetOutput(os.Stderr)
-	level, err := logrus.ParseLevel("debug")
-	if err != nil {
-		log.Fatal(err)
-	}
-	logger.SetLevel(level)
-
-	Logger = logger
-}
 
 func TestHttpApi(t *testing.T) {
 	ProdAPI = "https://prod.keyconjurer.local"

--- a/cli/keyconjurer/update_binary.go
+++ b/cli/keyconjurer/update_binary.go
@@ -21,7 +21,7 @@ func getBinaryName() string {
 
 // GetLatestBinary downloads the latest keyconjurer binary from the web.
 func GetLatestBinary() ([]byte, error) {
-	httpClient, err := getHTTPClientSingleton()
+	httpClient, err := createHTTPClient()
 	if err != nil {
 		return nil, fmt.Errorf("could not get HTTP client: %w", err)
 	}

--- a/cli/keyconjurer/update_binary.go
+++ b/cli/keyconjurer/update_binary.go
@@ -23,20 +23,18 @@ func getBinaryName() string {
 func GetLatestBinary() ([]byte, error) {
 	httpClient, err := getHTTPClientSingleton()
 	if err != nil {
-		Logger.Warnln("Error getting http client")
-		return nil, err
+		return nil, fmt.Errorf("could not get HTTP client: %w", err)
 	}
 
 	binaryURL := fmt.Sprintf("%s/%s", DownloadURL, getBinaryName())
 	req, _ := http.NewRequest(http.MethodGet, binaryURL, nil)
 	res, err := httpClient.Do(req)
 	if err != nil {
-		Logger.Errorf("Could not get binary upgrade. Reason: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("could not get binary upgrade: %w", err)
 	}
+
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		Logger.Errorln(err)
 		return nil, errors.New("Unable to parse response")
 	}
 	return body, nil

--- a/cli/keyconjurer/user_data.go
+++ b/cli/keyconjurer/user_data.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -52,7 +53,7 @@ func (u *UserData) ListAccounts() error {
 	return nil
 }
 
-// Alias links an AWS account to a new name for use w/ cli
+// NewAlias links an AWS account to a new name for use w/ cli
 func (u *UserData) NewAlias(accountName string, alias string) error {
 	for _, account := range u.Accounts {
 		if account.isNameMatch(accountName) {
@@ -63,12 +64,13 @@ func (u *UserData) NewAlias(accountName string, alias string) error {
 	return fmt.Errorf("Unable to find account %v and set alias %v", accountName, alias)
 }
 
-// Unalias removes the alias associated with the current account
+// RemoveAlias removes the alias associated with the current account
 func (u *UserData) RemoveAlias(accountName string) error {
 	account, err := u.FindAccount(accountName)
 	if err != nil {
 		return err
 	}
+
 	account.Alias = ""
 	account.defaultAlias()
 	return nil
@@ -78,40 +80,33 @@ func (u *UserData) RemoveAlias(accountName string) error {
 func (u *UserData) Save() error {
 	output, err := json.Marshal(u)
 	if err != nil {
-		Logger.Errorln(err)
 		return errors.New("Unable to parse JSON")
 	}
 
 	file, err := os.Create(u.filePath)
 	if err != nil {
-		Logger.Errorln(err)
-		return fmt.Errorf("Unable to create %v reason: %v", u.filePath, err)
+		return fmt.Errorf("Unable to create %s reason: %w", u.filePath, err)
 	}
 	defer file.Close()
 	if _, err := file.Write(output); err != nil {
-		Logger.Errorln(err)
-		return fmt.Errorf("Unable to write %v reason: %v", u.filePath, err)
+		return fmt.Errorf("Unable to write %s reason: %w", u.filePath, err)
 	}
 	return nil
 }
 
 // Load populates all member values of userData using default values where needed
-func (u *UserData) LoadFromFile() error {
-
-	body, err := ioutil.ReadFile(u.filePath)
+func (u *UserData) Load(reader io.Reader) error {
+	body, err := ioutil.ReadAll(reader)
 	if err != nil {
-		Logger.Errorln(err)
-		return fmt.Errorf("Unable to read %v", u.filePath)
+		return fmt.Errorf("unable to read %s: %w", u.filePath, err)
 	}
 
 	if err := json.Unmarshal(body, u); err != nil {
-		Logger.Warnln(err)
-		return fmt.Errorf("Unable to read json in %v", u.filePath)
+		return fmt.Errorf("unable to read json in %s: %w", u.filePath, err)
 	}
 
 	if u.TTL < 1 {
 		u.SetTTL(DefaultTTL)
-
 	}
 
 	if !u.Migrated {
@@ -128,15 +123,13 @@ func (u *UserData) SetDefaults() {
 
 // Prompts the user for the AD credentials and then passes back the list
 //  of AWS applications and encrypted creds via the inputed userData
-func (userData *UserData) promptForADCreds() error {
+func (u *UserData) promptForADCreds() error {
 	username, password, err := getUsernameAndPassword()
 	if err != nil {
-		Logger.Errorln(err)
 		return errors.New("Unable to get username or password")
 	}
 
-	if err := userData.getUserData(username, password); err != nil {
-		Logger.Errorln(err)
+	if err := u.getUserData(username, password); err != nil {
 		return errors.New("Unable to login")
 	}
 
@@ -145,19 +138,19 @@ func (userData *UserData) promptForADCreds() error {
 
 // GetUserData retrieves the list of AWS accounts the user has access too as well as the
 //  users encrypted credentials which is passed back via the inputed userData
-func (userData *UserData) getUserData(username string, password string) error {
+func (u *UserData) getUserData(username string, password string) error {
 	// client and version are build const(vars really)
-	data := newKeyConjurerUserRequestJSON(Client, Version, username, password)
-	responseUserData := &UserData{}
-
-	err := doKeyConjurerAPICall("/get_user_data", data, responseUserData)
+	data, err := newKeyConjurerUserRequestJSON(Client, Version, username, password)
 	if err != nil {
-		Logger.Warnln("error calling Key Conjurer /get_user_data api")
 		return err
 	}
 
-	userData.mergeNewUserData(responseUserData)
+	responseUserData := UserData{}
+	if err := doKeyConjurerAPICall("/get_user_data", data, &responseUserData); err != nil {
+		return fmt.Errorf("error calling Key Conjurer /get_user_data api: %w", err)
+	}
 
+	u.mergeNewUserData(&responseUserData)
 	return nil
 }
 
@@ -176,10 +169,8 @@ func (u *UserData) mergeNewUserData(toCopy *UserData) {
 
 	// merge in app and accounts
 	//  still use apps but populate accounts
-	Logger.Debugln("apps from keyconjurer:")
 	for _, app := range toCopy.Apps {
 		app.defaultAlias()
-		Logger.Debugf("\t%v\n", app)
 	}
 
 	if u.Accounts == nil {
@@ -201,7 +192,7 @@ func (u *UserData) mergeNewUserData(toCopy *UserData) {
 	}
 
 	// delete old not currently in accounts
-	for key, _ := range u.Accounts {
+	for key := range u.Accounts {
 		keyInList := false
 		for _, app := range toCopy.Apps {
 			if key == app.ID {

--- a/cli/keyconjurer/user_data.go
+++ b/cli/keyconjurer/user_data.go
@@ -140,17 +140,25 @@ func (u *UserData) promptForADCreds() error {
 //  users encrypted credentials which is passed back via the inputed userData
 func (u *UserData) getUserData(username string, password string) error {
 	// client and version are build const(vars really)
-	data, err := newKeyConjurerUserRequestJSON(Client, Version, username, password)
+	request := UserRequest{
+		Client:             Client,
+		ClientVersion:      Version,
+		Username:           username,
+		Password:           password,
+		ShouldEncryptCreds: true,
+	}
+
+	data, err := json.Marshal(request)
 	if err != nil {
 		return err
 	}
 
-	responseUserData := UserData{}
-	if err := doKeyConjurerAPICall("/get_user_data", data, &responseUserData); err != nil {
+	responseUserData := &UserData{}
+	if err := doKeyConjurerAPICall("/get_user_data", data, responseUserData); err != nil {
 		return fmt.Errorf("error calling Key Conjurer /get_user_data api: %w", err)
 	}
 
-	u.mergeNewUserData(&responseUserData)
+	u.mergeNewUserData(responseUserData)
 	return nil
 }
 

--- a/cli/keyconjurer/user_data_test.go
+++ b/cli/keyconjurer/user_data_test.go
@@ -1,25 +1,10 @@
 package keyconjurer
 
 import (
-	"log"
-	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
-
-func init() {
-	logger := logrus.New()
-	logger.SetOutput(os.Stderr)
-	level, err := logrus.ParseLevel("debug")
-	if err != nil {
-		log.Fatal(err)
-	}
-	logger.SetLevel(level)
-
-	Logger = logger
-}
 
 func TestSetTTL(t *testing.T) {
 	u := &UserData{}

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/riotgames/key-conjurer/cli/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This PR:

* Moves all logging of errors within the CLI to the root by propagating errors and using cobra's `RunE`
* Quiets the CLI by removing logging statements that are just for debugging purposes