### PR TITLE
add --shell flag

### DIFF
--- a/cli/credentials.go
+++ b/cli/credentials.go
@@ -11,6 +11,31 @@ import (
 	ps "github.com/mitchellh/go-ps"
 )
 
+type ShellType = string
+
+const (
+	shellTypePowershell ShellType = "powershell"
+	shellTypeBash       ShellType = "bash"
+	shellTypeBasic      ShellType = "basic"
+	shellTypeInfer      ShellType = "infer"
+)
+
+func getShellType() ShellType {
+	pid := os.Getppid()
+	parentProc, _ := ps.FindProcess(pid)
+	normalizedName := strings.ToLower(parentProc.Executable())
+
+	if strings.Contains(normalizedName, "powershell") || strings.Contains(normalizedName, "pwsh") {
+		return shellTypePowershell
+	}
+
+	if runtime.GOOS == "windows" {
+		return shellTypeBasic
+	}
+
+	return shellTypeBash
+}
+
 // AWSCredentials are used to store and print out temporary AWS Credentials
 // Note: verified that onelogin uses int as ID (so no leading 0's)
 // ... but does mean we can have negative user ids
@@ -49,30 +74,15 @@ func (c *AWSCredentials) ValidUntil(account Account, dur time.Duration) bool {
 	return expiration.After(time.Now().Add(dur))
 }
 
-/*
-Help Funcs
-*/
-
-func getShellType() string {
-	pid := os.Getppid()
-	parentProc, _ := ps.FindProcess(pid)
-	normalizedName := strings.ToLower(parentProc.Executable())
-
-	if strings.Contains(normalizedName, "powershell") || strings.Contains(normalizedName, "pwsh") {
-		return "powershell"
+func (c AWSCredentials) WriteFormat(w io.Writer, format ShellType) (int, error) {
+	var str string
+	if format == shellTypeInfer {
+		format = getShellType()
 	}
-	if runtime.GOOS == "windows" {
-		return "cmd"
-	}
-	return normalizedName
-}
 
-// Write detects the users shell and outputs the credentials for use  as environment variables for said shell
-func (c AWSCredentials) String() string {
-	exportStatement := ""
-	switch getShellType() {
-	case "powershell":
-		exportStatement = `$Env:AWS_ACCESS_KEY_ID = "%v"
+	switch format {
+	case shellTypePowershell:
+		str = `$Env:AWS_ACCESS_KEY_ID = "%v"
 $Env:AWS_SECRET_ACCESS_KEY = "%v"
 $Env:AWS_SESSION_TOKEN = "%v"
 $Env:AWS_SECURITY_TOKEN = "%v"
@@ -82,8 +92,8 @@ $Env:TF_VAR_token = $Env:AWS_SESSION_TOKEN
 $Env:AWSKEY_EXPIRATION = "%v"
 $Env:AWSKEY_ACCOUNT = "%v"
 `
-	case "cmd":
-		exportStatement = `SET AWS_ACCESS_KEY_ID=%v
+	case shellTypeBasic:
+		str = `SET AWS_ACCESS_KEY_ID=%v
 SET AWS_SECRET_ACCESS_KEY=%v
 SET AWS_SESSION_TOKEN=%v
 SET AWS_SECURITY_TOKEN=%v
@@ -93,10 +103,8 @@ SET TF_VAR_token=%%AWS_SESSION_TOKEN%%
 SET AWSKEY_EXPIRATION=%v
 SET AWSKEY_ACCOUNT=%v
 `
-	case "bash":
-		fallthrough
-	default:
-		exportStatement = `export AWS_ACCESS_KEY_ID=%v
+	case shellTypeBash:
+		str = `export AWS_ACCESS_KEY_ID=%v
 export AWS_SECRET_ACCESS_KEY=%v
 export AWS_SESSION_TOKEN=%v
 export AWS_SECURITY_TOKEN=%v
@@ -108,11 +116,5 @@ export AWSKEY_ACCOUNT=%v
 `
 	}
 
-	return fmt.Sprintf(exportStatement, c.AccessKeyID, c.SecretAccessKey, c.SessionToken, c.SessionToken, c.Expiration, c.AccountID)
-}
-
-// Write detects the users shell and outputs the credentials for use  as environment variables for said shell
-func (c AWSCredentials) Write(w io.Writer) error {
-	_, err := fmt.Fprintln(w, c.String())
-	return err
+	return fmt.Fprintf(w, str, c.AccessKeyID, c.SecretAccessKey, c.SessionToken, c.SessionToken, c.Expiration, c.AccountID)
 }


### PR DESCRIPTION
This PR adds `--shell` to `keyconjurer get`. `--shell` allows a user to determine
which output format will be used to output credentials to standard output if `--out`
is set to `env`.

This is useful for users on Windows running KeyConjurer in WSL;
KeyConjurer determines the OS as Windows and so outputs variables in
Windows' BASIC format, which cannot be executed in a subshell by
default.

The options for this new flag are as follows:

* `basic` - Output credentials in Windows' command prompt format, BASIC.
* `bash` - Output credentials in a format that all Bash and Bash-alike
shells may use.
* `powershell` - Output credentials in PowerShell format.
* `infer` - KeyConjurer determines which shell you are using and then
outputs credentials in a format for that shell. This was the previous
behavior. If the shell cannot be determined, then the output will be
formatted as if the user had selected `bash`.

If `--shell` is omitted, then `infer` will be chosen by default, which
matches the previous behaviour. Example usage:

  keyconjurer get my-account --shell bash