### PR TITLE
API should return specific HTTP status codes

### DIFF
--- a/api/keyconjurer/responses.go
+++ b/api/keyconjurer/responses.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
 )
 
 // Response is the generic structure of the lambda responses.
@@ -70,11 +73,17 @@ func (r *Response) GetError(dest *ErrorData) error {
 	return json.Unmarshal(raw, dest)
 }
 
-// DataResponse returns a response that wraps the data in the correct format.
+// DataResponse returns a response that wraps the data in an APIGatewayProxyResponse in the correct format.
 // Error is always nil to make returning from a Lambda less cumbersome.
-func DataResponse(data interface{}) (Response, error) {
+func DataResponse(data interface{}) (*events.APIGatewayProxyResponse, error) {
 	// Message must be "success" for legacy clients to correctly interpret it
-	return Response{Success: true, Message: "success", Data: data}, nil
+	response := Response{Success: true, Message: "success", Data: data}
+	body, err := json.Marshal(response)
+	if err != nil {
+		return GetAPIGatewayProxyResponse(ErrCodeInternalServerError, []byte("JSON encoding failed"))
+	}
+
+	return GetAPIGatewayProxyResponse(Success, body)
 }
 
 var (
@@ -86,19 +95,42 @@ var (
 	ErrCodeUnspecified ErrorCode = "unspecified"
 	// ErrCodeUnableToDecrypt indicates the server was unable to decrypt the credentials the client provided.
 	ErrCodeUnableToDecrypt ErrorCode = "decryption_failure"
-	// ErrCodeInvalidCredentials indicates that the users credentials were incorrect
+	// ErrCodeInvalidCredentials indicates that the users credentials were incorrect.
 	ErrCodeInvalidCredentials ErrorCode = "invalid_credentials"
 	// ErrCodeInternalServerError indicates that a server occurred within the server and the server could not continue.
 	// The user cannot fix this issue. They MAY retry again.
 	ErrCodeInternalServerError ErrorCode = "internal_server_error"
 	// ErrCodeUnableToEncrypt indicates that the server was unable to encrypt the users credentials.
 	ErrCodeUnableToEncrypt ErrorCode = "encryption_failure"
-	// ErrBadRequest indicates that the user supplied data that was invalid
+	// ErrBadRequest indicates that the user supplied data that was invalid.
 	ErrBadRequest ErrorCode = "bad_request"
+	// Success indicates that everything went well.
+	Success ErrorCode = "successful"
 )
 
 // ErrorCode contains all of the recognised error codes in the KeyConjurer API.
 type ErrorCode string
+
+// GetHttpStatus translates an error code to an HTTP status code.
+func (e ErrorCode) GetHttpStatus() int {
+	switch e {
+	case Success:
+		return http.StatusOK
+	case ErrBadRequest:
+		return http.StatusBadRequest
+	case ErrCodeInvalidProvider:
+		return http.StatusBadRequest
+	case ErrCodeUnspecified:
+		return http.StatusBadRequest
+	case ErrCodeUnableToDecrypt:
+		return http.StatusBadRequest
+	case ErrCodeUnableToEncrypt:
+		return http.StatusBadRequest
+	case ErrCodeInvalidCredentials:
+		return http.StatusForbidden
+	}
+	return http.StatusInternalServerError
+}
 
 // ErrorData encapsulates error information relating to an AWS Lambda call.
 // Lambda does not make it trivial to return HTTP status codes, so instead the application should interrogate the Code value in this struct.
@@ -113,8 +145,27 @@ func (e ErrorData) Error() string {
 
 var _ error = ErrorData{}
 
-// ErrorResponse creates a standardized error response with an error message from the server.
+// ErrorResponse creates a standardized error response with an error message from the server
+// and wraps it in an APIGatewayProxyResponse that the AWS API gateway understands.
 // It also always returns a nil error, simply to make returning from a Lambda less cumbersome.
-func ErrorResponse(code ErrorCode, message string) (Response, error) {
-	return Response{Success: false, Message: message, Data: ErrorData{Code: code, Message: message}}, nil
+func ErrorResponse(code ErrorCode, message string) (*events.APIGatewayProxyResponse, error) {
+	response := Response{Success: false, Message: message, Data: ErrorData{Code: code, Message: message}}
+	body, err := json.Marshal(response)
+	if err != nil {
+		return GetAPIGatewayProxyResponse(ErrCodeInternalServerError, []byte("JSON encoding failed"))
+	}
+
+	return GetAPIGatewayProxyResponse(code, body)
+}
+
+// GetAPIGatewayProxyResponse creates a response that wraps data in an APIGatewayProxyResponse that the AWS API Gateway understands.
+// It also sets an HTTP status code based on a specified error code.
+func GetAPIGatewayProxyResponse(code ErrorCode, data []byte) (*events.APIGatewayProxyResponse, error) {
+	return &events.APIGatewayProxyResponse{
+		StatusCode:        code.GetHttpStatus(),
+		Headers:           map[string]string{"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+		MultiValueHeaders: make(map[string][]string),
+		Body:              string(data),
+		IsBase64Encoded:   false,
+	}, nil
 }

--- a/api/keyconjurer/responses_test.go
+++ b/api/keyconjurer/responses_test.go
@@ -2,20 +2,86 @@ package keyconjurer
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+type T struct {
+	Foo, Bar string
+}
+
+func TestDataResponse(t *testing.T) {
+	data := T{Foo: "Foo", Bar: "Qux"}
+	proxyResponse, err := DataResponse(data)
+	require.NoError(t, err, "no error should be returned")
+	require.NotNil(t, proxyResponse, "data response should not be nil")
+	require.Equal(t, 200, proxyResponse.StatusCode, "unexpected status code")
+	require.Equal(t, "application/json", proxyResponse.Headers["Content-Type"], "unexpeted content type")
+	require.Equal(t, "*", proxyResponse.Headers["Access-Control-Allow-Origin"], "unexpected CORS header")
+
+	var response Response
+	response.UnmarshalJSON([]byte(proxyResponse.Body))
+	require.True(t, response.Success)
+	require.Equal(t, "success", response.Message)
+}
+
+func TestErrorResponse(t *testing.T) {
+	message := "wrong credentials"
+	proxyResponse, err := ErrorResponse(ErrCodeInvalidCredentials, message)
+	require.NoError(t, err)
+	require.NotNil(t, proxyResponse)
+	require.Equal(t, 403, proxyResponse.StatusCode, "unexpected status code")
+	require.Equal(t, "application/json", proxyResponse.Headers["Content-Type"], "unexpeted content type")
+	require.Equal(t, "*", proxyResponse.Headers["Access-Control-Allow-Origin"], "unexpected CORS header")
+
+	var response Response
+	response.UnmarshalJSON([]byte(proxyResponse.Body))
+	require.False(t, response.Success)
+	require.Equal(t, message, response.Message)
+}
+
+func TestErrorResponseStatusCodes(t *testing.T) {
+	proxyResponse, err := ErrorResponse(ErrBadRequest, "bad request")
+	require.NoError(t, err)
+	require.NotNil(t, proxyResponse)
+	require.Equal(t, 400, proxyResponse.StatusCode, "unexpected status code")
+
+	proxyResponse, err = ErrorResponse(ErrCodeInternalServerError, "bad request")
+	require.NoError(t, err)
+	require.NotNil(t, proxyResponse)
+	require.Equal(t, 500, proxyResponse.StatusCode, "unexpected status code")
+}
+
 func TestResponseMarshalJSON(t *testing.T) {
-	type T struct {
-		Foo, Bar string
-	}
+	response, err := DataResponse(T{Foo: "Foo", Bar: "Qux"})
+	require.NoError(t, err)
 
-	data, _ := DataResponse(T{Foo: "Foo", Bar: "Qux"})
-	b, _ := json.Marshal(data)
+	b, err := json.Marshal(response)
+	require.NoError(t, err)
 
-	require.Equal(t, `{"Success":true,"Message":"success","Data":{"Foo":"Foo","Bar":"Qux"}}`, string(b))
+	expectedBody := `{\"Success\":true,\"Message\":\"success\",\"Data\":{\"Foo\":\"Foo\",\"Bar\":\"Qux\"}}`
+	expectedHeaders := `{"Access-Control-Allow-Origin":"*","Content-Type":"application/json"}`
+	expectedData := fmt.Sprintf(`{"statusCode":200,"headers":%s,"multiValueHeaders":{},"body":"%s"}`, expectedHeaders, expectedBody)
+	require.Equal(t, expectedData, string(b))
+}
+
+func TestErrorResponseMarshalJSON(t *testing.T) {
+	message := "this is a error message"
+
+	response, err := ErrorResponse(ErrBadRequest, message)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	b, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
+	expectedBody := fmt.Sprintf(`{\"Success\":false,\"Message\":\"%s\",\"Data\":{\"Code\":\"bad_request\",\"Message\":\"%s\"}}`, message, message)
+	expectedHeaders := `{"Access-Control-Allow-Origin":"*","Content-Type":"application/json"}`
+	expectedData := fmt.Sprintf(`{"statusCode":400,"headers":%s,"multiValueHeaders":{},"body":"%s"}`, expectedHeaders, expectedBody)
+	require.Equal(t, expectedData, string(b))
 }
 
 func TestResponseGetPayload(t *testing.T) {

--- a/api/keyconjurer/serverless_functions.go
+++ b/api/keyconjurer/serverless_functions.go
@@ -2,9 +2,11 @@ package keyconjurer
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/riotgames/key-conjurer/api/authenticators/duo"
 	"github.com/riotgames/key-conjurer/api/authenticators/okta"
@@ -66,8 +68,15 @@ type GetUserDataPayload struct {
 // GetUserDataEventHandler authenticates the user against OneLogin and retrieves a list of AWS application the user has available.
 //
 // This MUST be backwards compatible with the old version of KeyConjurer for a time.
-func (h *Handler) GetUserDataEventHandler(ctx context.Context, event GetUserDataEvent) (Response, error) {
+func (h *Handler) GetUserDataEventHandler(ctx context.Context, req *events.APIGatewayProxyRequest) (*events.APIGatewayProxyResponse, error) {
 	log := h.log
+
+	var event GetUserDataEvent
+	if err := json.Unmarshal([]byte(req.Body), &event); err != nil {
+		log.Errorf("unable to parse incoming JSON: %s", err)
+		return ErrorResponse(ErrBadRequest, "unable to parse incoming JSON")
+	}
+
 	if err := h.crypt.Decrypt(ctx, &event.Credentials); err != nil {
 		log.Errorf("unable to decrypt credentials: %s", err)
 		return ErrorResponse(ErrCodeUnableToDecrypt, "unable to decrypt credentials")
@@ -150,8 +159,15 @@ type GetTemporaryCredentialsPayload struct {
 // GetTemporaryCredentialEventHandler issues temporary credentials for the current user.
 //
 // This MUST be backwards compatible with the old version of KeyConjurer for a time.
-func (h *Handler) GetTemporaryCredentialEventHandler(ctx context.Context, event GetTemporaryCredentialEvent) (Response, error) {
+func (h *Handler) GetTemporaryCredentialEventHandler(ctx context.Context, req *events.APIGatewayProxyRequest) (*events.APIGatewayProxyResponse, error) {
 	log := h.log
+
+	var event GetTemporaryCredentialEvent
+	if err := json.Unmarshal([]byte(req.Body), &event); err != nil {
+		log.Errorf("unable to parse incoming JSON: %s", err)
+		return ErrorResponse(ErrBadRequest, "unable to parse incoming JSON")
+	}
+
 	if err := event.Validate(); err != nil {
 		log.Infof("bad request: %s", err.Error())
 		return ErrorResponse(ErrBadRequest, err.Error())
@@ -219,7 +235,7 @@ type ListProvidersPayload struct {
 // ListProvidersHandler allows a user to list the providers they may authenticate with.
 //
 // This does NOT need to be backwards compatible with old KeyConjurer clients.
-func (h *Handler) ListProvidersHandler(ctx context.Context) (Response, error) {
+func (h *Handler) ListProvidersHandler(ctx context.Context) (*events.APIGatewayProxyResponse, error) {
 	var p []Provider
 	for key := range h.authenticationProviders {
 		p = append(p, Provider{ID: key})

--- a/api/testserver/main.go
+++ b/api/testserver/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/riotgames/key-conjurer/api/keyconjurer"
 	"github.com/riotgames/key-conjurer/api/settings"
 )
@@ -18,14 +20,14 @@ func (s *server) getAWSCreds(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var ev keyconjurer.GetTemporaryCredentialEvent
-	dec := json.NewDecoder(r.Body)
-	if err := dec.Decode(&ev); err != nil {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	resp, err := s.h.GetTemporaryCredentialEventHandler(r.Context(), ev)
+	request := &events.APIGatewayProxyRequest{Body: string(body)}
+	resp, err := s.h.GetTemporaryCredentialEventHandler(r.Context(), request)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -41,14 +43,14 @@ func (s *server) getUserData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var ev keyconjurer.GetUserDataEvent
-	dec := json.NewDecoder(r.Body)
-	if err := dec.Decode(&ev); err != nil {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	resp, err := s.h.GetUserDataEventHandler(r.Context(), ev)
+	request := &events.APIGatewayProxyRequest{Body: string(body)}
+	resp, err := s.h.GetUserDataEventHandler(r.Context(), request)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/terraform/aws/gateway_post_endpoint/endpoint.tf
+++ b/terraform/aws/gateway_post_endpoint/endpoint.tf
@@ -17,12 +17,12 @@ resource "aws_api_gateway_method_response" "endpoint_method_responses" {
 }
 
 
-resource "aws_api_gateway_integration" "endpoint_integrations" {
+resource "aws_api_gateway_integration" "endpoint_proxy_integrations" {
   rest_api_id             = var.rest_api_id
   resource_id             = var.resource_id
   http_method             = aws_api_gateway_method.endpoint_method.http_method
   integration_http_method = aws_api_gateway_method.endpoint_method.http_method
-  type                    = "AWS"
+  type                    = "AWS_PROXY"
   uri                     = var.uri_arn
   depends_on              = [aws_api_gateway_method.endpoint_method]
 }
@@ -35,7 +35,7 @@ resource "aws_api_gateway_integration_response" "endpoint_integration_responses"
   response_parameters = {
     "method.response.header.Access-Control-Allow-Origin" = "'*'"
   }
-  depends_on = [aws_api_gateway_integration.endpoint_integrations, aws_api_gateway_method_response.endpoint_method_responses]
+  depends_on = [aws_api_gateway_integration.endpoint_proxy_integrations, aws_api_gateway_method_response.endpoint_method_responses]
 }
 
 resource "aws_lambda_permission" "lambda_permissions" {


### PR DESCRIPTION
Currently, the API always return 200 or 5xx no matter what happened.

Main updates:
* Updated the AWS API Gateway to use proxy integration
* Updated the Lambda handlers to work with the Gateway proxy
* Updated the CLI to expect not only 200 and 5xx
* Added several unit tests