### PR TITLE
Use right NopCloser

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ aws s3api create-bucket --bucket <terraform state bucket> --region us-west-2 --c
 
 ## Setup Build Environment
 
-- go 1.12.4+
+- go 1.13.4+
 - npm 6.4.1+
 - node 10.10.0+
 - tfswitch

--- a/api/README.md
+++ b/api/README.md
@@ -2,7 +2,7 @@
 Key Conjurer provides temporary AWS API credentials! Key Conjurer uses OneLogin and Duo to retrieve STS tokens.
 
 ## Requirements
-Go 1.12.4+
+Go 1.13.4+
 
 # Deployment
 

--- a/api/authenticators/okta/okta_auth_test.go
+++ b/api/authenticators/okta/okta_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -54,7 +55,7 @@ var testOktaUrl url.URL = url.URL{}
 
 // MakeBody wraps a string into an io.ReadCloser.
 func MakeBody(s string) io.ReadCloser {
-	return io.NopCloser(strings.NewReader(s))
+	return ioutil.NopCloser(strings.NewReader(s))
 }
 
 func TestAuthnWithOktaErrors(t *testing.T) {


### PR DESCRIPTION
Use older `ioutil.NopCloser` to support older Go versions.