### PR TITLE
Add Build Timestamp to `--version` output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ frontend/build/**
 api/lambdas/get_aws_creds/get_aws_creds
 api/lambdas/get_user_data/get_user_data
 *.bak
+.vscode
 
 # Created by https://www.gitignore.io/api/go,vim,osx,node,emacs,windows,terraform
 # Edit at https://www.gitignore.io/?templates=go,vim,osx,node,emacs,windows,terraform

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ aws s3api create-bucket --bucket <terraform state bucket> --region us-west-2 --c
 
 ## Setup Build Environment
 
+- make
 - go 1.13.4+
 - npm 6.4.1+
 - node 10.10.0+
@@ -143,3 +144,10 @@ Encryption was previously tied to the `Provider` interface listed above, but it 
 We'll happily accept a pull request making the use of encryption providers a choice at runtime.
 
 [cryptoprovider]: ./api/core/crypto.go
+
+# Unit Tests for cli client code
+
+```bash
+source prod.env
+make cli_test
+```

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
-Key Conjurer CLI
+# Key Conjurer CLI
 ======
 Go-based CLI interface for Key Conjurer API. This tool
 enables you to retrieve temporary AWS API credentials. It can be used in automation.
@@ -162,7 +162,7 @@ $ keyconjurer get <accountName/alias> --time-remaining <N>
 # or
 $ keyconjurer get <accountName/alias> -t <N> 
 ```
-By default `N=60` so that any call will always request new keys. 
+By default `N=5` so that any call will always request new keys if there is less than 5 minutes left. 
 
 keyconjurer checks to see if the account you are requesting keys for is not the account 
 you currently have keys for. If the accounts differ, new API keys are requested and a 

--- a/cli/accounts.go
+++ b/cli/accounts.go
@@ -8,14 +8,14 @@ import (
 )
 
 func init() {
-	accountsCmd.Flags().StringVar(&identityProvider, "identity-provider", defaultIdentityProvider, "The identity provider to use. Refer to `keyconjurer identity-providers` for more info.")
+	accountsCmd.Flags().StringVar(&identityProvider, "identity-provider", defaultIdentityProvider, "The identity provider to use. Refer to `"+appname+" identity-providers` for more info.")
 }
 
 var accountsCmd = &cobra.Command{
-	Use:     "accounts",
-	Short:   "Prints the list of accounts you have access to.",
-	Long:    "Prints the list of accounts you have access to.",
-	Example: "keyconjurer accounts",
+	Use:   "accounts",
+	Short: "Prints the list of accounts you have access to.",
+	Long:  "Prints the list of accounts you have access to.",
+	// Example: appname + " accounts",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		client, err := newClient()

--- a/cli/alias.go
+++ b/cli/alias.go
@@ -9,7 +9,7 @@ var aliasCmd = cobra.Command{
 	Short:   "Give an account a nickname.",
 	Long:    "Alias an account to a nickname so you can refer to the account by the nickname.",
 	Args:    cobra.ExactArgs(2),
-	Example: "keyconjurer alias FooAccount Bar",
+	Example: "  " + appname + " alias FooAccount Bar",
 	Run: func(cmd *cobra.Command, args []string) {
 		config.Alias(args[0], args[1])
 	}}

--- a/cli/consts.go
+++ b/cli/consts.go
@@ -7,8 +7,12 @@ import (
 )
 
 // Vars for build time
-var Version string = "go run"
+var Version string = "TBD"
 var ClientName string = "go runtime"
+
+var BuildDate string = "date not set"
+var BuildTime string = "time not set"
+var BuildTimeZone string = "zone not set"
 
 // Var for switching APIs
 var Dev bool = false
@@ -20,12 +24,14 @@ const DefaultTTL uint = 1
 const DefaultTimeRemaining uint = 5
 
 // available API  endpoints
-var DownloadURL string
+var DownloadURL string = "URL not set yet"
 
 // CLI binary names
 const LinuxBinaryName string = "keyconjurer-linux"
 const WindowsBinaryName string = "keyconjurer-windows.exe"
 const DarwinBinaryName string = "keyconjurer-darwin"
+
+const appname string = "keyconjurer"
 
 // CLI HTTP Timeouts
 var ClientHttpTimeoutInSeconds time.Duration = 30

--- a/cli/get.go
+++ b/cli/get.go
@@ -34,7 +34,7 @@ func init() {
 	getCmd.Flags().StringVarP(&shell, "shell", "", shellTypeInfer, "If output type is env, determines which format to output credentials in - by default, the format is inferred based on the execution environment. WSL users may wish to overwrite this to `bash`")
 	getCmd.Flags().StringVarP(&awsCliPath, "awscli", "", "~/.aws/", "Path for directory used by the aws-cli tool. Default is \"~/.aws\".")
 	getCmd.Flags().StringVar(&roleName, "role", "", "The name of the role to assume.")
-	getCmd.Flags().StringVar(&identityProvider, "identity-provider", defaultIdentityProvider, "The identity provider to use. Refer to `keyconjurer identity-providers` for more info.")
+	getCmd.Flags().StringVar(&identityProvider, "identity-provider", defaultIdentityProvider, "The identity provider to use. Refer to `"+appname+" identity-providers` for more info.")
 }
 
 var getCmd = &cobra.Command{
@@ -43,8 +43,8 @@ var getCmd = &cobra.Command{
 	Long: `Retrieves temporary AWS API credentials for the specified account.  It sends a push request to the first Duo device it finds associated with your account.
 
 A role must be specified when using this command through the --role flag. You may list the roles you can assume through the roles command.`,
-	Example: "keyconjurer get <accountName/alias>",
-	Args:    cobra.ExactArgs(1),
+	// Example: appname + " get <accountName/alias>",
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		client, err := newClient()

--- a/cli/login.go
+++ b/cli/login.go
@@ -51,10 +51,10 @@ func init() {
 }
 
 var loginCmd = &cobra.Command{
-	Use:     "login",
-	Short:   "Authenticate with KeyConjurer.",
-	Long:    "Login using your AD creds. This stores encrypted credentials on the local system.",
-	Example: "keyconjurer login",
+	Use:   "login",
+	Short: "Authenticate with KeyConjurer.",
+	Long:  "Login using your AD creds. This stores encrypted credentials on the local system.",
+	// Example: appname + " login",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		client, err := newClient()

--- a/cli/makefile
+++ b/cli/makefile
@@ -2,6 +2,10 @@
 
 version = $(shell git rev-parse --short HEAD)
 
+build_date =  $(shell date -u +'%Y-%m-%d')
+build_time =  $(shell date -u +'%H:%M:%S')
+build_timezone = UTC
+
 ifndef API_URL
 $(error API_URL is not set)
 endif
@@ -12,26 +16,46 @@ ifndef TF_WORKSPACE
 $(error TF_WORKSPACE is not set)
 endif
 
+.PHONY: all linux  darwin windows build dir test build_requirements
+
+
 all: linux darwin windows
 
+
+linux: export GOOS=linux
+linux: export BUILD_TARGET=keyconjurer-linux
 linux: dir
-	export os=linux \
-	&& GOOS=linux go build -ldflags "-X main.Version=$(version)-$(TF_WORKSPACE) -X main.ClientName=keyconjurer-linux -X main.defaultHost=$(API_URL) -X main.DownloadURL=$(FRONTEND_URL)" -o ../builds/$(TF_WORKSPACE)/cli/keyconjurer-linux
+	make build
 
-darwin:
-	export os=darwin \
-	&& GOOS=darwin go build -ldflags "-X main.Version=$(version)-$(TF_WORKSPACE) -X main.ClientName=keyconjurer-darwin -X main.defaultHost=$(API_URL) -X main.DownloadURL=$(FRONTEND_URL)" -o ../builds/$(TF_WORKSPACE)/cli/keyconjurer-darwin
 
-windows:
-	export os=windows \
-	&& GOOS=windows go build -ldflags "-X main.Version=$(version)-$(TF_WORKSPACE) -X main.ClientName=keyconjurer-windows -X main.defaultHost=$(API_URL) -X main.DownloadURL=$(FRONTEND_URL)" -o ../builds/$(TF_WORKSPACE)/cli/keyconjurer-windows.exe
+darwin: export GOOS=darwin
+darwin: export BUILD_TARGET=keyconjurer-darwin
+darwin: dir
+	make build
+
+
+windows: export GOOS=windows
+windows: export BUILD_TARGET=keyconjurer-windows.exe
+windows: dir
+	make build
 
 dir:
 	mkdir -p ../builds/$(TF_WORKSPACE)/cli
 
+build: dir
+	go build \
+		-ldflags "-X main.Version=$(version)-$(TF_WORKSPACE) -X main.ClientName=keyconjurer-$(GOOS) -X main.defaultHost=$(API_URL) -X main.DownloadURL=$(FRONTEND_URL) -X main.BuildDate=$(build_date) -X main.BuildTime=$(build_time) -X main.BuildTimeZone=$(build_timezone)" \
+		-o ../builds/$(TF_WORKSPACE)/cli/$(BUILD_TARGET)
+
 test: dir
-	mkdir -p ~/.aws \
-	&& touch ~/.aws/config \
-	&& touch ~/.aws/credentials \
-	&& touch ~/.keyconjurerrc \
-	&& go test -v ./...
+	mkdir -p ~/.aws 
+	touch ~/.aws/config 
+	touch ~/.aws/credentials 
+	touch ~/.keyconjurerrc 
+	go test -v ./...
+
+build_requirements:
+	go version
+	gcc --version
+	make --version
+

--- a/cli/providers.go
+++ b/cli/providers.go
@@ -18,7 +18,7 @@ If KeyConjurer supports multiple providers, you may specify one you wish to use 
 
 If you do not specify an --identity-provider flag for the commands that support it (get, login, accounts) a default identity provider will be chosen for you (default: %q).
 `, defaultIdentityProvider),
-	Example: "keyconjurer identity-providers",
+	// Example: appname + " identity-providers",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 		client, err := newClient()

--- a/cli/roles.go
+++ b/cli/roles.go
@@ -13,7 +13,7 @@ func init() {
 
 var rolesCmd = cobra.Command{
 	Use:   "roles",
-	Short: "List all the roles that you can assume when using `keyconjurer get`.",
+	Short: "List all the roles that you can assume when using `" + appname + " get`.",
 	RunE: func(*cobra.Command, []string) error {
 		switch identityProvider {
 		case keyconjurer.AuthenticationProviderOneLogin:

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Required to reset Cobra state between Test runs.
+// If you add new tests that change state, you may need to
+// add code here to reset the side effects of other tests
+func resetCobra(cmd *cobra.Command) {
+
+	cmdShortVersionFlag = false
+	cmdOneLineVersionFlag = false
+
+	helpflag := cmd.Flags().Lookup("help")
+	if helpflag != nil {
+		helpflag.Value.Set("false")
+	}
+
+	verflag := cmd.Flags().Lookup("version")
+	if verflag != nil {
+		verflag.Value.Set("false")
+	}
+}
+
+func execute(cmd *cobra.Command, args ...string) (string, error) {
+
+	cmd.SetArgs(args)
+
+	outputbuf := new(bytes.Buffer)
+
+	cmd.SetOutput(outputbuf)
+
+	err := cmd.Execute()
+
+	return outputbuf.String(), err
+}
+
+func stringContains(t *testing.T, testTarget, shouldBeHere string) {
+	if !strings.Contains(testTarget, shouldBeHere) {
+		t.Errorf("Missing Content:\n   [%v]\nShould have been in here:\n   %v\n", shouldBeHere, testTarget)
+	}
+}
+
+func stringOmits(t *testing.T, testTarget, shouldNotBeHere string) {
+	if strings.Contains(testTarget, shouldNotBeHere) {
+		t.Errorf("Extra Content that should not be found here:\n   [%v]\nBut it was:\n   %v", shouldNotBeHere, testTarget)
+	}
+}
+
+func stringChecks(t *testing.T, testTarget string, shouldBeHere, shouldNotBeHere []string) {
+	expectedTermsMissing := []string{}
+	notExpectedTermsFound := []string{}
+
+	for _, v := range shouldBeHere {
+		if !strings.Contains(testTarget, v) {
+			expectedTermsMissing = append(expectedTermsMissing, v)
+		}
+	}
+	for _, v := range shouldNotBeHere {
+		if strings.Contains(testTarget, v) {
+			notExpectedTermsFound = append(notExpectedTermsFound, v)
+		}
+	}
+
+	missing := ""
+	found := ""
+
+	if len(expectedTermsMissing) > 0 {
+		missing = fmt.Sprintf("Content missing that was expected:\n   %v\n", expectedTermsMissing)
+	}
+	if len(notExpectedTermsFound) > 0 {
+		found = fmt.Sprintf("Content found that was not expected:\n   %v\n", notExpectedTermsFound)
+	}
+	if len(notExpectedTermsFound) > 0 || len(expectedTermsMissing) > 0 {
+		t.Errorf("\n%v%vString being checked:\n---------------\n%v\n---------------\n", missing, found, testTarget)
+	}
+}
+
+func TestHelpCommand(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{rootCmd.Long, "-s, --short-version", "-1, --oneline-version"},
+		[]string{})
+}
+
+func TestHelpFlag(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "--help")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{rootCmd.Long, "-s, --short-version", "-1, --oneline-version"},
+		[]string{})
+}
+
+func TestHelpShortFlag(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "-h")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{rootCmd.Long, "-s, --short-version", "-1, --oneline-version"},
+		[]string{})
+}
+
+func TestHelpNoCommand(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{rootCmd.Long, "-s, --short-version", "-1, --oneline-version"},
+		[]string{})
+}
+
+func TestVersionFlag(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "--version")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{"Version:", "Build Timestamp:", "Client:", "Default Hostname:", "Upgrade URL:", appname, Version, DownloadURL},
+		[]string{})
+}
+
+func TestVersionShortFlag(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "-v")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{"Version:", "Build Timestamp:", "Client:", "Default Hostname:", "Upgrade URL:", appname, Version, DownloadURL},
+		[]string{})
+}
+
+func TestOneLineVersionFlag(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "--oneline-version")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{appname, Version, "Client:", "(Build Timestamp:"},
+		[]string{"Version:", "Default Hostname:", "Upgrade URL:", DownloadURL})
+}
+
+func TestOneLineVersionShortFlag(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "-1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{appname, Version, "Client:", "(Build Timestamp:"},
+		[]string{"Version:", "Default Hostname:", "Upgrade URL:", DownloadURL})
+}
+
+func TestShortVersionFlag(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "--short-version")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{appname, Version},
+		[]string{"Version:", "Build Timestamp:", "Client:", "Default Hostname:", "Upgrade URL:", DownloadURL})
+}
+
+func TestShortVersionShortFlag(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "-s")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	stringChecks(t, output,
+		[]string{appname, Version},
+		[]string{"Version:", "Build Timestamp:", "Client:", "Default Hostname:", "Upgrade URL:", DownloadURL})
+}
+
+func TestShortVersionLongInvalidArgs(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "--short-version", "get")
+	if err != nil {
+		if err.Error() != "unknown flag: --short-version" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	} else {
+		t.Errorf("Unexpected non-error, output=: %v", output)
+	}
+}
+
+func TestHelpLongInvalidArgs(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "get", "-s")
+	if err != nil {
+		if err.Error() != "unknown shorthand flag: 's' in -s" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	} else {
+		t.Errorf("Unexpected non-error, output=: %v", output)
+	}
+}
+
+func TestInvalidCommand(t *testing.T) {
+
+	resetCobra(rootCmd)
+
+	output, err := execute(rootCmd, "badcommand")
+	if err != nil {
+		if err.Error() != "unknown command \"badcommand\" for \""+appname+"\"" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	} else {
+		t.Errorf("Unexpected non-error, output=: %v", output)
+	}
+}
+
+// Runs multiple tests that set flags & state and ensures the resetCobra() function
+// is properly re-initializing state so test run as expected
+func TestResetCobra(t *testing.T) {
+
+	TestShortVersionShortFlag(t)
+	TestOneLineVersionFlag(t)
+	TestHelpShortFlag(t)
+	TestVersionFlag(t)
+	TestShortVersionShortFlag(t)
+}

--- a/cli/switch.go
+++ b/cli/switch.go
@@ -32,7 +32,7 @@ This is used when a "bastion" account exists which users initially authenticate 
 
 This command will fail if you do not have active AWS credentials.
 `,
-	Example: `keyconjurer switch 123456798`,
+	Example: "  " + appname + ` switch 123456798`,
 	Args:    cobra.ExactArgs(1),
 	Aliases: []string{"switch-account"},
 	RunE: func(comm *cobra.Command, args []string) error {

--- a/cli/unalias.go
+++ b/cli/unalias.go
@@ -8,7 +8,7 @@ var unaliasCmd = cobra.Command{
 	Use:     "unalias <accountName/alias>",
 	Short:   "Remove alias from account.",
 	Args:    cobra.ExactArgs(1),
-	Example: "keyconjurer unalias bar",
+	Example: "  " + appname + " unalias bar",
 	Run: func(cmd *cobra.Command, args []string) {
 		config.Unalias(args[0])
 	}}

--- a/cli/upgrade.go
+++ b/cli/upgrade.go
@@ -12,11 +12,11 @@ import (
 )
 
 var upgradeCmd = &cobra.Command{
-	Use:     "upgrade",
-	Short:   "Downloads the latest version of keyconjurer.",
-	Long:    "Downloads the latest version of keyconjurer.",
-	Args:    cobra.ExactArgs(0),
-	Example: "keyconjurer upgrade",
+	Use:   "upgrade",
+	Short: "Downloads the latest version of " + appname + ".",
+	Long:  "Downloads the latest version of " + appname + ".",
+	Args:  cobra.ExactArgs(0),
+	// Example: appname + " upgrade",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		keyConjurerRcPath, err := os.Executable()
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/valyala/fastjson v1.6.3
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
-	golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/ini.v1 v1.42.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -459,10 +459,8 @@ golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 h1:W0lCpv29Hv0UaM1LXb9QlBHLNP8UFfcKjblhVCWftOM=
-golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 h1:W0lCpv29Hv0UaM1LXb9QlBHLNP8UFfcKjblhVCWftOM=
-golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/makefile
+++ b/makefile
@@ -6,6 +6,10 @@ ifndef CLOUD_PROVIDER
 $(error CLOUD_PROVIDER is not set)
 endif
 
+.DEFAULT_GOAL = build
+
+.PHONY: build api_build frontend_build cli_build frontend_file_reset reset_files deploy deploy_aws plan_aws
+
 build:
 	make cli_build \
 	&& make api_build \
@@ -21,7 +25,7 @@ frontend_build:
 	cd frontend \
 	&& $(MAKE) -f makefile build
 
-cli_build:
+cli_build: go_tidy
 	mkdir -p builds/$(TF_WORKSPACE)/cli
 	cd cli \
 	&& $(MAKE) -f makefile all
@@ -37,10 +41,21 @@ ifeq ($(CLOUD_PROVIDER),aws)
 	make deploy_aws
 endif
 
-deploy_aws: 
+deploy_aws:
 	cd terraform/aws \
 	&& $(MAKE) -f makefile deploy
 
 plan_aws:
 	cd terraform/aws \
 	&& $(MAKE) -f makefile plan_deploy
+
+
+.PHONY: go_tidy test
+
+go_tidy:
+	go mod tidy
+
+cli_test: go_tidy
+	mkdir -p builds/$(TF_WORKSPACE)/cli
+	cd cli \
+	&& $(MAKE) -f makefile test


### PR DESCRIPTION
The primary goal of this pull request is to expose the recency of the client version, as the build hash of the GitHub version is not human-friendly.   Additionally, I added two additional flags `--short-version` & `--oneline-version` to aid automation use cases.

```
$ ./builds/prod/cli/keyconjurer-linux --short-version
keyconjurer 15ea992-prod
$ ./builds/prod/cli/keyconjurer-linux --oneline-version
keyconjurer 15ea992-prod (Build Timestamp:2022-05-27 21:20:06 UTC - Client:keyconjurer-linux)
$ ./builds/prod/cli/keyconjurer-linux --version
        Version:                15ea992-prod
        Build Timestamp:        2022-05-27 21:20:06 UTC
        Client:                 keyconjurer-linux
        Default Hostname:       https://api.keyconjurer.yourdomain.com
        Upgrade URL:            https://keyconjurer.yourdomain.com
```

Other changes in this PR:
* added `.vscode` to `.gitignore`
* updated version of `golang.org/x/sys` in `go.mod` & `go.sum` to address build failures when using go 1.18 to compile darwin build target
* added new make target to root makefile to make running `cli` go test easier `make cli_test`
* added `go mod tidy` to build & test make targets to ensure go dependency changes get picked up in the mod files.
* updated `cli` README.md to match code default for `--time-remaining`
* refactored `cli` makefile
* added go tests for new flags
* removed redundant usage 'Examples' in Cobra commands
* refactored generic application name ("keyconjurer") to feed off of a const rather than exist in multiple different places
