### PR TITLE
add support for providing a code to Duo ahead of time instead of using Push

### DIFF
--- a/api/authenticators/okta/authenticator.go
+++ b/api/authenticators/okta/authenticator.go
@@ -73,12 +73,11 @@ func (a *Authenticator) GenerateSAMLAssertion(ctx context.Context, creds core.Cr
 		return nil, fmt.Errorf("%w: appID cannot be an empty string", core.ErrBadRequest)
 	}
 
-	app, _, err := a.client.Application.GetApplication(ctx, appID, &okta.Application{}, query.NewQueryParams())
+	var appl okta.Application
+	_, _, err := a.client.Application.GetApplication(ctx, appID, &appl, query.NewQueryParams())
 	if err != nil {
 		return nil, core.WrapError(core.ErrApplicationNotFound, err)
 	}
-
-	appl := app.(*okta.Application)
 
 	st, err := a.oktaAuthClient.Authn(ctx, authnRequest{Username: creds.Username, Password: creds.Password})
 	if err != nil {
@@ -116,7 +115,7 @@ func (a *Authenticator) GenerateSAMLAssertion(ctx context.Context, creds core.Cr
 		return nil, wrapOktaError(err, core.ErrCouldNotCreateSession)
 	}
 
-	samlResponse, err := a.oktaAuthClient.GetSAMLResponse(ctx, *appl, session)
+	samlResponse, err := a.oktaAuthClient.GetSAMLResponse(ctx, appl, session)
 	if err != nil {
 		return nil, wrapOktaError(err, core.ErrSAMLError)
 	}

--- a/api/core/authentication_provider.go
+++ b/api/core/authentication_provider.go
@@ -56,6 +56,10 @@ type AuthenticationProvider interface {
 	GenerateSAMLAssertion(ctx context.Context, credentials Credentials, appID string) (*SAMLResponse, AuthenticationProviderError)
 }
 
+type MfaEnabledAuthenticationProvider interface {
+	GenerateSAMLAssertionWithMFACode(ctx context.Context, credentials Credentials, appID, mfaCode string) (*SAMLResponse, AuthenticationProviderError)
+}
+
 // AuthenticationProviderError is an error returned by an authentication provider.
 type AuthenticationProviderError error
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -113,6 +113,7 @@ type GetCredentialsOptions struct {
 	Credentials            core.Credentials
 	ApplicationID          string
 	TimeoutInHours         uint8
+	MFACode                string
 	RoleName               string
 	AuthenticationProvider keyconjurer.AuthenticationProviderName
 }
@@ -133,6 +134,7 @@ func (c *Client) GetCredentials(ctx context.Context, opts *GetCredentialsOptions
 		TimeoutInHours:         opts.TimeoutInHours,
 		RoleName:               opts.RoleName,
 		AuthenticationProvider: opts.AuthenticationProvider,
+		MFACode:                opts.MFACode,
 	}
 
 	buf, err := c.encodeJSON(request)

--- a/cli/get.go
+++ b/cli/get.go
@@ -19,6 +19,7 @@ var (
 	roleName       string
 	cloudFlag      string
 	shell          string = shellTypeInfer
+	mfaCode        string
 )
 
 var (
@@ -42,6 +43,7 @@ func init() {
 	getCmd.Flags().StringVar(&roleName, "role", "", "The name of the role to assume.")
 	getCmd.Flags().StringVarP(&cloudFlag, "cloud", "", "aws", "Choose a cloud vendor. Default is aws. Can choose aws or tencent")
 	getCmd.Flags().StringVar(&identityProvider, "identity-provider", defaultIdentityProvider, "The identity provider to use. Refer to `"+appname+" identity-providers` for more info.")
+	getCmd.Flags().StringVarP(&mfaCode, "mfa-code", "m", "", "The MFA code to use. If provided, will not issue a push to a mobile device. This can be considerably faster and more secure than push notifications, but requires more user effort to employ.")
 }
 
 var getCmd = &cobra.Command{
@@ -132,6 +134,7 @@ var getCmd = &cobra.Command{
 		credentials, err = client.GetCredentials(ctx, &GetCredentialsOptions{
 			Credentials:            creds,
 			ApplicationID:          applicationID,
+			MFACode:                strings.TrimSpace(mfaCode),
 			RoleName:               roleName,
 			TimeoutInHours:         uint8(ttl),
 			AuthenticationProvider: identityProvider,


### PR DESCRIPTION
### what does it do?

This adds a new function, `SendMFACode`, to the Duo package, which allows a user to provide a multi-factor code. This could be solicited from terminal input before sending a request to Okta. Using this flow, the user is able to authenticate with Duo without having to use the Duo push flow.

### why should we do it?

#### Speed

Duo pushes are very slow. At Riot, we have frequently seen Duo pushes take 15-20 seconds to send, to the point where occasionally the request to KeyConjurer times out.

#### Rate limits

Duo has an invisible rate limit of 10 requests or so per minute. In some rare situations, engineers may need to authenticate into more than 10 applications per minute. While having to generate 10 codes and enter them one-by-one might be painful, it is surely better than getting opaque errors and being forced to wait.

#### Security

[Recent news coverage][uber] has shown the vulnerability of push notifications: Primarily, that push notifications lead to fatigue and users may feel compelled to just hit "Yes" if they receive many push notifications rather than continuing to press "No" in the hopes of their phone no longer vibrating. This may lead to an attacker gaining access to a system.

With the option to provide codes, users may be able to become better conditioned to report Duo push notifications they did not initiate.


### WIP

This branch is not finished. There needs to be tests, and much of the Duo code needs to have some slightly renamed types to better describe return values - for example, `sendMfaCode` does not actually return a Duo push response (as there was no push initiated), but a Duo status check.

[uber]: https://www.vice.com/en/article/5d35yd/the-uber-hack-shows-push-notification-2fa-has-a-downside-its-too-annoying