### PR TITLE
Disable accounts select if the accounts list is empty [Tiny improvement at the UI]

### DIFF
--- a/frontend/src/components/keyRequestForm.jsx
+++ b/frontend/src/components/keyRequestForm.jsx
@@ -164,7 +164,7 @@ class KeyRequestForm extends Component {
               <Form.Group widths='equal'>
                 <Form.Field>
                   <label htmlFor="account">Account</label>
-                  <select className='ui field dropdown selection' id="account" placeholder={accountPlaceHolder} onChange={this.setAccount} value={selectedAccount}>
+                  <select className='ui field dropdown selection' disabled={!accounts.length} id="account" placeholder={accountPlaceHolder} onChange={this.setAccount} value={selectedAccount}>
                     {accounts.map(({ name, id }) =>
                       <option key={id} value={id}>{name}</option>
                     )}


### PR DESCRIPTION
Disabling the accounts select if the accounts list is empty. 

- Tested the change by updating the store to check if the select only disables if there is no accounts at the accounts list.
- The accounts placeholder doesn't show up, i'll take a look on that later on (should i create an issue on these little improvements?)
- I'm currently running only the frontend, cause i'm still digging on the API code to discover a way to run it

This is my first contribution at an open source project, i'll appreciate any tips or good practices for contributing here =)

Before:
![image](https://user-images.githubusercontent.com/62081192/213899476-8e659049-bcb8-4ee5-abaa-dc35d71652bc.png)

After:
![image](https://user-images.githubusercontent.com/62081192/213899480-7b059174-f8dc-46a6-b3a5-885cd76b0b44.png)

