### PR TITLE
Fix a bug where users with multiple prompts could not authenticate

### DIFF
--- a/providers/okta/application_test.go
+++ b/providers/okta/application_test.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -30,4 +31,85 @@ func Test_ApplicationSAMLSource_GetAssertion(t *testing.T) {
 	t.Logf("AccessKeyID: %s", *resp2.AccessKeyID)
 	t.Logf("SecretAccessKey: %s", *resp2.SecretAccessKey)
 	t.Logf("SessionToken: %s", *resp2.SessionToken)
+}
+
+func Test_findIdpRemediation(t *testing.T) {
+	blob := `
+{
+	"rel": [
+		"create-form"
+	],
+	"name": "select-authenticator-authenticate",
+	"href": "https://sso.example.com/idp/idx/challenge",
+	"method": "POST",
+	"produces": "application/ion+json; okta-version=1.0.0",
+	"value": [
+		{
+			"name": "authenticator",
+			"type": "object",
+			"options": [
+				{
+					"label": "the label you are looking for",
+					"value": {
+						"form": {
+							"value": [
+								{
+									"name": "id",
+									"required": true,
+									"value": "the id you are looking for",
+									"mutable": false
+								},
+								{
+									"name": "methodType",
+									"required": false,
+									"value": "idp",
+									"mutable": false
+								}
+							]
+						}
+					},
+					"relatesTo": "$.authenticatorEnrollments.value[0]"
+				},
+				{
+					"label": "not the label you are looking for",
+					"value": {
+						"form": {
+							"value": [
+								{
+									"name": "id",
+									"required": true,
+									"value": "not the id you are looking for",
+									"mutable": false
+								},
+								{
+									"name": "methodType",
+									"required": false,
+									"value": "duo",
+									"mutable": false
+								}
+							]
+						}
+					},
+					"relatesTo": "$.authenticatorEnrollments.value[1]"
+				}
+			]
+		},
+		{
+			"name": "stateHandle",
+			"required": true,
+			"value": "a state handle",
+			"visible": false,
+			"mutable": false
+		}
+	],
+	"accepts": "application/json; okta-version=1.0.0"
+}
+`
+
+	var rem Remediation
+	require.NoError(t, json.Unmarshal([]byte(blob), &rem))
+
+	authenticatorId, ok := findIdpAuthenticatorId(rem)
+	assert.True(t, ok)
+	assert.Equal(t, "the id you are looking for", authenticatorId)
 }

--- a/providers/okta/duo_iframe.go
+++ b/providers/okta/duo_iframe.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"net/http/httputil"
 
 	"github.com/riotgames/key-conjurer/pkg/htmlutil"
 	"github.com/riotgames/key-conjurer/providers/duo"
@@ -57,6 +59,9 @@ func (f DuoIframe) Upgrade(ctx context.Context, client *http.Client) ([]byte, er
 	req, _ = http.NewRequestWithContext(ctx, "GET", gjson.GetBytes(bodyBuf, "success.href").Str, nil)
 	resp, err = client.Do(req)
 	if err != nil {
+		respDump, _ := httputil.DumpResponse(resp, true)
+		log.Printf("Failed to issue initial DuoIframe request: %s", err)
+		log.Printf("Response: %s", string(respDump))
 		return nil, fmt.Errorf("failed to issue initial DuoIframe request: %w", err)
 	}
 


### PR DESCRIPTION
If Okta presented the user with multiple options to select when authenticating, KeyConjurer would get stuck. This change resolves this issue by selecting the first IDP-factor for the user.

As best I can tell, this issue only occurred for users opted into both Duo as an OIDC factor and yubikeys.