### PR TITLE
Tencent Cloud suport

### DIFF
--- a/cli/accounts.go
+++ b/cli/accounts.go
@@ -109,6 +109,8 @@ func refreshAccounts(ctx context.Context, serverAddr *url.URL, tok *oauth2.Token
 			ID:    app.ID,
 			Name:  app.Name,
 			Alias: generateDefaultAlias(app.Name),
+			Href:  app.Href,
+			Type:  app.Type,
 		}
 	}
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -11,6 +11,7 @@ import (
 
 	"strings"
 
+	"github.com/riotgames/key-conjurer/internal/api"
 	"golang.org/x/oauth2"
 )
 
@@ -23,10 +24,12 @@ type TokenSet struct {
 }
 
 type Account struct {
-	ID             string `json:"id"`
-	Name           string `json:"name"`
-	Alias          string `json:"alias"`
-	MostRecentRole string `json:"most_recent_role"`
+	ID             string              `json:"id"`
+	Name           string              `json:"name"`
+	Alias          string              `json:"alias"`
+	MostRecentRole string              `json:"most_recent_role"`
+	Href           string              `json:"href"`
+	Type           api.ApplicationType `json:"type"`
 }
 
 func (a *Account) NormalizeName() string {
@@ -153,8 +156,9 @@ func (a *accountSet) ReplaceWith(other []Account) {
 		clone := acc
 		// Preserve the alias if the account ID is the same and it already exists
 		if entry, ok := a.accounts[acc.ID]; ok {
-			// The name is the only thing that might change.
 			entry.Name = acc.Name
+			entry.Href = acc.Href
+			entry.Type = acc.Type
 		} else {
 			a.accounts[acc.ID] = &clone
 		}

--- a/cli/oauth2.go
+++ b/cli/oauth2.go
@@ -237,9 +237,6 @@ func ExchangeAccessTokenForWebSSOToken(ctx context.Context, client *http.Client,
 	}
 }
 
-var ()
-
-// TODO: This is actually an Okta-specific API
 func ExchangeWebSSOTokenForSAMLAssertion(ctx context.Context, client *http.Client, issuer string, token *oauth2.Token) ([]byte, error) {
 	if client == nil {
 		client = http.DefaultClient

--- a/cli/oauth2.go
+++ b/cli/oauth2.go
@@ -19,6 +19,24 @@ import (
 	"golang.org/x/oauth2"
 )
 
+var (
+	// ErrTokenExchangeNotSupported indicates that token exchange is not supported for the given application.
+	//
+	// This most commonly occurs when attempting to use token exchange on non-AWS applications with Okta.
+	// Okta currently (2023-09-25) only supports the web sso grant type for AWS applications.
+	ErrTokenExchangeNotSupported = errors.New("token exchange not supported")
+)
+
+// ErrOktaErrorResponse is returned when Okta returns a non-200 response that is not covered by other well-defined errors.
+type ErrOktaErrorResponse struct {
+	StatusCode int
+	Response   *http.Response
+}
+
+func (e ErrOktaErrorResponse) Error() string {
+	return fmt.Sprintf("bad response code: %d", e.StatusCode)
+}
+
 // stateBufSize is the size of the buffer used to generate the state parameter.
 // 43 is a magic number - It generates states that are not too short or long for Okta's validation.
 const stateBufSize = 43
@@ -206,9 +224,20 @@ func ExchangeAccessTokenForWebSSOToken(ctx context.Context, client *http.Client,
 		return nil, err
 	}
 
-	var tok oauth2.Token
-	return &tok, json.NewDecoder(resp.Body).Decode(&tok)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var tok oauth2.Token
+		return &tok, json.NewDecoder(resp.Body).Decode(&tok)
+	case http.StatusBadRequest:
+		// Unsupported application - This application probably hasn't been configured to support token exchange.
+		// In other words, it's probably not an AWS application.
+		return nil, ErrTokenExchangeNotSupported
+	default:
+		return nil, ErrOktaErrorResponse{resp.StatusCode, resp}
+	}
 }
+
+var ()
 
 // TODO: This is actually an Okta-specific API
 func ExchangeWebSSOTokenForSAMLAssertion(ctx context.Context, client *http.Client, issuer string, token *oauth2.Token) ([]byte, error) {

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/riotgames/key-conjurer/internal/api"
+)
+
+func main() {
+	url, err := url.Parse(os.Getenv("OIDC_DOMAIN"))
+	if err != nil {
+		log.Fatalf("failed to parse OIDC_DOMAIN as URL: %s", url)
+	}
+
+	okta := api.NewOktaService(url, os.Getenv("OKTA_TOKEN"))
+	http.Handle("/v2/applications", api.ServeUserApplications(okta))
+	http.ListenAndServe(":8080", nil)
+}

--- a/internal/api/json.go
+++ b/internal/api/json.go
@@ -18,7 +18,9 @@ func ServeJSON[T any](w http.ResponseWriter, data T) {
 	// Nothing we can do to respond to the error message here either
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(buf)
-	slog.Error("could not write JSON to the client: %s", err)
+	if err != nil {
+		slog.Error("could not write JSON to the client: %s", err)
+	}
 }
 
 type JSONError struct {

--- a/internal/api/serverless_functions.go
+++ b/internal/api/serverless_functions.go
@@ -9,9 +9,18 @@ import (
 	"golang.org/x/exp/slog"
 )
 
+type ApplicationType string
+
+var (
+	ApplicationTypeOIDC ApplicationType = "oidc"
+	ApplicationTypeSAML ApplicationType = "saml"
+)
+
 type Application struct {
-	ID   string `json:"@id"`
-	Name string `json:"name"`
+	ID   string          `json:"@id"`
+	Name string          `json:"name"`
+	Type ApplicationType `json:"type"`
+	Href string          `json:"href"`
 }
 
 type OktaService interface {
@@ -49,16 +58,35 @@ func ServeUserApplications(okta OktaService) http.Handler {
 
 		var accounts []Application
 		for _, app := range applications {
-			if app.AppName == "amazon_aws" || strings.Contains(app.AppName, "tencent") {
-				accounts = append(accounts, Application{
-					ID:   app.AppInstanceId,
-					Name: app.Label,
-				})
+			typ, ok := deriveApplicationType(app)
+			if !ok {
+				continue
 			}
+
+			app := Application{
+				ID:   app.AppInstanceId,
+				Name: app.Label,
+				Type: typ,
+				Href: app.LinkUrl,
+			}
+
+			accounts = append(accounts, app)
 		}
 
 		requestAttrs = append(requestAttrs, slog.Int("application_count", len(accounts)))
 		slog.Info("served applications", requestAttrs...)
 		ServeJSON(w, accounts)
 	})
+}
+
+func deriveApplicationType(app *okta.AppLink) (ApplicationType, bool) {
+	if app.AppName == "amazon_aws" {
+		return ApplicationTypeOIDC, true
+	}
+
+	if strings.Contains(app.AppName, "tencent") {
+		return ApplicationTypeSAML, true
+	}
+
+	return "", false
 }

--- a/internal/api/serverless_functions.go
+++ b/internal/api/serverless_functions.go
@@ -84,7 +84,7 @@ func deriveApplicationType(app *okta.AppLink) (ApplicationType, bool) {
 		return ApplicationTypeOIDC, true
 	}
 
-	if strings.Contains(app.AppName, "tencent") {
+	if strings.Contains(strings.ToLower(app.AppName), "tencent") {
 		return ApplicationTypeSAML, true
 	}
 

--- a/internal/api/serverless_functions.go
+++ b/internal/api/serverless_functions.go
@@ -12,8 +12,8 @@ import (
 type ApplicationType string
 
 var (
-	ApplicationTypeOIDC ApplicationType = "oidc"
-	ApplicationTypeSAML ApplicationType = "saml"
+	ApplicationTypeAWS     ApplicationType = "aws"
+	ApplicationTypeTencent ApplicationType = "tencent"
 )
 
 type Application struct {
@@ -81,11 +81,11 @@ func ServeUserApplications(okta OktaService) http.Handler {
 
 func deriveApplicationType(app *okta.AppLink) (ApplicationType, bool) {
 	if app.AppName == "amazon_aws" {
-		return ApplicationTypeOIDC, true
+		return ApplicationTypeAWS, true
 	}
 
 	if strings.Contains(strings.ToLower(app.AppName), "tencent") {
-		return ApplicationTypeSAML, true
+		return ApplicationTypeTencent, true
 	}
 
 	return "", false


### PR DESCRIPTION
This PR re-implements Tencent Cloud support for KeyConjurer v2.

There are a few limitations to Tencent Cloud support which make it less-than-seamless to use:

* Tencent Cloud applications cannot use the Token Exchange endpoint in Okta due to Okta limitations, which means that sessions must instead be initiated by directly visiting the application URL.
* Consequently, the application URL and a type flag must be added to the returned applications from our API to indicate that an application is a Tencent Cloud application and stored within the configuration.
* Because it's not possible to construct the link with _just_ the application ID, the `--bypass-cache` flag cannot be used with Tencent applications; a Tencent Cloud application must be within the cache.
