### PR TITLE
Update MacUsage.md

### DIFF
--- a/frontend/src/articles/MacUsage.md
+++ b/frontend/src/articles/MacUsage.md
@@ -17,7 +17,7 @@ Open a terminal and execute the following commands.
 
 Next, add `~/.bin` to your `$PATH`. With the Zsh shell (pre-installed with most Macs), this can be accomplished in the Terminal with:
 
-    $ echo 'export PATH="$PATH:~/.bin"' >> ~/.zshrc
+    $ echo 'export PATH="$PATH:$HOME/.bin"' >> ~/.zshrc
 
 Restart your shell.
 


### PR DESCRIPTION
Updated installation instructions to replace ~ with the home path, was preventing PATH from picking up the binary