### PR TITLE
Improve error handling when TTL is invalid

### DIFF
--- a/cli/consts.go
+++ b/cli/consts.go
@@ -12,7 +12,7 @@ var (
 
 const (
 	// DefaultTTL for requested credentials in hours
-	DefaultTTL uint = 8
+	DefaultTTL uint = 1
 	// DefaultTimeRemaining for new key requests in minutes
 	DefaultTimeRemaining  uint   = 5
 	LinuxAmd64BinaryName  string = "keyconjurer-linux-amd64"

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_tryParseTimeToLiveError(t *testing.T) {
+	validationError := awserr.New("ValidationError", "Value '86400' at 'durationSeconds' failed to satisfy constraint: Member must have value less than or equal to 43200", nil)
+	err, ok := tryParseTimeToLiveError(validationError)
+
+	require.True(t, ok)
+	require.NotNil(t, err)
+	require.Equal(t, err.Error(), "you requested a TTL of 24 hours, but the maximum for this configuration is 12 hours")
+	var ttlError TimeToLiveError
+	require.ErrorAs(t, err, &ttlError)
+	require.Equal(t, ttlError.MaxDuration, 43200*time.Second)
+	require.Equal(t, ttlError.RequestedDuration, 86400*time.Second)
+	require.Equal(t, ttlError.Code(), ExitCodeValueError)
+}

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -9,15 +9,31 @@ import (
 )
 
 func Test_tryParseTimeToLiveError(t *testing.T) {
-	validationError := awserr.New("ValidationError", "Value '86400' at 'durationSeconds' failed to satisfy constraint: Member must have value less than or equal to 43200", nil)
-	err, ok := tryParseTimeToLiveError(validationError)
+	t.Run("UnambiguousAmount", func(t *testing.T) {
+		validationError := awserr.New("ValidationError", "1 validation error detected: Value '86400' at 'durationSeconds' failed to satisfy constraint: Member must have value less than or equal to 43200", nil)
+		err, ok := tryParseTimeToLiveError(validationError)
 
-	require.True(t, ok)
-	require.NotNil(t, err)
-	require.Equal(t, err.Error(), "you requested a TTL of 24 hours, but the maximum for this configuration is 12 hours")
-	var ttlError TimeToLiveError
-	require.ErrorAs(t, err, &ttlError)
-	require.Equal(t, ttlError.MaxDuration, 43200*time.Second)
-	require.Equal(t, ttlError.RequestedDuration, 86400*time.Second)
-	require.Equal(t, ttlError.Code(), ExitCodeValueError)
+		require.True(t, ok)
+		require.NotNil(t, err)
+		require.Equal(t, err.Error(), "you requested a TTL of 24 hours, but the maximum for this configuration is 12 hours")
+		var ttlError TimeToLiveError
+		require.ErrorAs(t, err, &ttlError)
+		require.Equal(t, ttlError.MaxDuration, 43200*time.Second)
+		require.Equal(t, ttlError.RequestedDuration, 86400*time.Second)
+		require.Equal(t, ttlError.Code(), ExitCodeValueError)
+	})
+
+	t.Run("AmbiguousAmount", func(t *testing.T) {
+		validationError := awserr.New("ValidationError", "The requested DurationSeconds exceeds the MaxSessionDuration set for this role.", nil)
+		err, ok := tryParseTimeToLiveError(validationError)
+
+		require.True(t, ok)
+		require.NotNil(t, err)
+		require.Equal(t, err.Error(), "the TTL you requested exceeds the maximum TTL for this configuration")
+		var ttlError TimeToLiveError
+		require.ErrorAs(t, err, &ttlError)
+		require.Equal(t, ttlError.MaxDuration, time.Duration(0))
+		require.Equal(t, ttlError.RequestedDuration, time.Duration(0))
+		require.Equal(t, ttlError.Code(), ExitCodeValueError)
+	})
 }

--- a/cli/get.go
+++ b/cli/get.go
@@ -107,11 +107,6 @@ A role must be specified when using this command through the --role flag. You ma
 			return ValueError{Value: shellType, ValidValues: permittedShellTypes}
 		}
 
-		// make sure we enforce limit
-		if ttl > 8 {
-			ttl = 8
-		}
-
 		var accountID string
 		if len(args) > 0 {
 			accountID = args[0]
@@ -177,8 +172,15 @@ A role must be specified when using this command through the --role flag. You ma
 				SAMLAssertion:   &assertionStr,
 			})
 
+			if err, ok := tryParseTimeToLiveError(err); ok {
+				return err
+			}
+
 			if err != nil {
-				return AWSError{InnerError: err, Message: "failed to exchange credentials"}
+				return AWSError{
+					InnerError: err,
+					Message:    "failed to exchange credentials",
+				}
 			}
 
 			credentials = CloudCredentials{

--- a/cli/main.go
+++ b/cli/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"golang.org/x/exp/slog"
 )
 
@@ -28,10 +29,11 @@ func main() {
 	err := rootCmd.Execute()
 	var codeErr codeError
 	if errors.As(err, &codeErr) {
-		rootCmd.PrintErrf("keyconjurer: %s\n", codeErr.Error())
+		cobra.CheckErr(codeErr)
 		os.Exit(int(codeErr.Code()))
 	} else if err != nil {
-		rootCmd.PrintErrf("keyconjurer: %s\n", err.Error())
+		// Probably a cobra error.
+		cobra.CheckErr(err)
 		os.Exit(ExitCodeUnknownError)
 	}
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -102,4 +102,5 @@ To get started run the following commands:
 		return config.Write(file)
 	},
 	SilenceErrors: true,
+	SilenceUsage:  true,
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/RobotsAndPencils/go-saml v0.0.0-20170520135329-fb13cb52a46b
 	github.com/aws/aws-lambda-go v1.19.1
 	github.com/aws/aws-sdk-go v1.34.19
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.148.2
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/go-ini/ini v1.61.0
 	github.com/hashicorp/go-rootcerts v1.0.2
@@ -24,6 +25,7 @@ require (
 )
 
 require (
+	github.com/aws/smithy-go v1.20.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,11 @@ github.com/aws/aws-lambda-go v1.19.1/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XO
 github.com/aws/aws-sdk-go v1.34.10/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.19 h1:x3MMvAJ1nfWviixEduchBSs65DgY5Y2pA2/NAcxVGOo=
 github.com/aws/aws-sdk-go v1.34.19/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go-v2 v1.25.1 h1:P7hU6A5qEdmajGwvae/zDkOq+ULLC9tQBTwqqiwFGpI=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.148.2 h1:1oOlVyfM5Lzn/XKjqoVyy2i4OQhqOPaqYg3Jk+cZ4FE=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.148.2/go.mod h1:7MUTgVVnC1GAxx4SNQqzQalrm1n4v1HYa/R/LEB3CKo=
+github.com/aws/smithy-go v1.20.1 h1:4SZlSlMr36UEqC7XOyRVb27XMeZubNcBNN+9IgEPIQw=
+github.com/aws/smithy-go v1.20.1/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=


### PR DESCRIPTION
A common error scenario when requesting keys using `keyconjurer get` was that the ttl would exceed the maximum allowed for the account + role. This error would be displayed as "failed to exchange credentials" with no additional info.

This PR fixes this issue by:

* Reducing default TTL back down to 8 from 1
* Displaying a unique error if the TTL is invalid.