### PR TITLE
Extend ecosystems in Dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,15 @@ updates:
     # Check the for updates once a week
     schedule:
       interval: "weekly"
+  # Enable version updates for Go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Extending https://github.com/RiotGames/key-conjurer/pull/116 with additional package ecosystems used in the repository, reference https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories