### PR TITLE
Silence browser output

### DIFF
--- a/command/login.go
+++ b/command/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 
@@ -16,6 +17,12 @@ import (
 	"github.com/spf13/pflag"
 	"golang.org/x/oauth2"
 )
+
+func init() {
+	// Silence stdout/stderr from browsers
+	browser.Stdout = io.Discard
+	browser.Stderr = io.Discard
+}
 
 var (
 	FlagURLOnly   = "url-only"


### PR DESCRIPTION
Fix a bug where, on Linux, output from the Firefox browser would pollute stdout/stderr. See:

```
$ go run . login

Gtk-Message: 15:10:16.957: Not loading module "atk-bridge": The functionality is provided by GTK natively. Please try to not load it.
[893230, Main Thread] WARNING: GTK+ module /snap/firefox/4793/gnome-platform/usr/lib/gtk-2.0/modules/libcanberra-gtk-module.so cannot be loaded.
GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported.: 'glib warning', file /build/firefox/parts/firefox/build/toolkit/xre/nsSigHandlers.cpp:187

(firefox:893230): Gtk-WARNING **: 15:10:16.983: GTK+ module /snap/firefox/4793/gnome-platform/usr/lib/gtk-2.0/modules/libcanberra-gtk-module.so cannot be loaded.
GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported.
Gtk-Message: 15:10:16.983: Failed to load module "canberra-gtk-module"
[893230, Main Thread] WARNING: GTK+ module /snap/firefox/4793/gnome-platform/usr/lib/gtk-2.0/modules/libcanberra-gtk-module.so cannot be loaded.
GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported.: 'glib warning', file /build/firefox/parts/firefox/build/toolkit/xre/nsSigHandlers.cpp:187

(firefox:893230): Gtk-WARNING **: 15:10:16.983: GTK+ module /snap/firefox/4793/gnome-platform/usr/lib/gtk-2.0/modules/libcanberra-gtk-module.so cannot be loaded.
GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported.
Gtk-Message: 15:10:16.983: Failed to load module "canberra-gtk-module"
```