### PR TITLE
get command now supports a custom awscli profile

### DIFF
--- a/command/awsconfig.go
+++ b/command/awsconfig.go
@@ -17,10 +17,13 @@ type CloudCliEntry struct {
 	token       string
 }
 
-func NewCloudCliEntry(c CloudCredentials, a *Account) CloudCliEntry {
-	name := a.Name
+func NewCloudCliEntry(c CloudCredentials, a *Account, profileName string) CloudCliEntry {
+	name := a.Name                    // 1. Account name (fallback)
 	if a.Alias != "" {
-		name = a.Alias
+		name = a.Alias                // 2. Account alias (if set)
+	}
+	if profileName != "" {
+		name = profileName            // 3. Profile name override (if provided, highest priority)
 	}
 
 	return CloudCliEntry{

--- a/command/awsconfig_test.go
+++ b/command/awsconfig_test.go
@@ -9,6 +9,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewCloudCliEntry(t *testing.T) {
+	creds := CloudCredentials{
+		AccessKeyID:     "test-key-id",
+		SecretAccessKey: "test-secret-key",
+		SessionToken:    "test-session-token",
+	}
+
+	tests := []struct {
+		name                string
+		account             *Account
+		profileName         string
+		expectedProfileName string
+	}{
+		{
+			name:                "uses account name when no alias or profile override",
+			account:             &Account{ID: "123", Name: "my-account"},
+			profileName:         "",
+			expectedProfileName: "my-account",
+		},
+		{
+			name:                "uses alias over account name",
+			account:             &Account{ID: "123", Name: "my-account", Alias: "my-alias"},
+			profileName:         "",
+			expectedProfileName: "my-alias",
+		},
+		{
+			name:                "profile override takes precedence over account name",
+			account:             &Account{ID: "123", Name: "my-account"},
+			profileName:         "custom-profile",
+			expectedProfileName: "custom-profile",
+		},
+		{
+			name:                "profile override takes precedence over alias",
+			account:             &Account{ID: "123", Name: "my-account", Alias: "my-alias"},
+			profileName:         "custom-profile",
+			expectedProfileName: "custom-profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := NewCloudCliEntry(creds, tt.account, tt.profileName)
+			assert.Equal(t, tt.expectedProfileName, entry.profileName)
+		})
+	}
+}
+
 func TestAddAWSCliEntry(t *testing.T) {
 	file, err := ini.Load(bytes.NewReader([]byte{}))
 	require.NoError(t, err)

--- a/command/switch.go
+++ b/command/switch.go
@@ -104,7 +104,7 @@ func (s SwitchCommand) Execute(ctx context.Context) error {
 		return nil
 	case outputTypeAWSCredentialsFile:
 		acc := Account{ID: s.AccountID, Name: s.AccountID}
-		newCliEntry := NewCloudCliEntry(creds, &acc)
+		newCliEntry := NewCloudCliEntry(creds, &acc, "")
 		return SaveCloudCredentialInCLI(s.AWSCLIPath, newCliEntry)
 	default:
 		return fmt.Errorf("%s is an invalid output type", s.OutputType)


### PR DESCRIPTION
Adding a `-p` option to customize the awscli profile name the credentials are save to:
```
keyconjurer get my-account --role LC-my-role --out awscli -p my-profile
```
This allows for using two profiles in the same account, for example.